### PR TITLE
Add support for knn enhanced ar(x) forecastors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Suggests:
     lubridate,
     RcppRoll,
     rmarkdown,
+    tensr,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 URL: https://github.com/cmu-delphi/epipredict/,

--- a/R/arx_forecaster.R
+++ b/R/arx_forecaster.R
@@ -37,7 +37,9 @@ arx_forecaster <- function(x, y, key_vars, time_value,
   if (intercept) dat$x0 <- 1
 
   obj <- stats::lm(
-    y1 ~ . + 0, data = dat %>% dplyr::select(starts_with(c("x","y"))))
+    y1 ~ . + 0,
+    data = dat %>% dplyr::select(starts_with(c("x", "y")))
+  )
 
   point <- make_predictions(obj, dat, time_value, keys)
 
@@ -50,8 +52,9 @@ arx_forecaster <- function(x, y, key_vars, time_value,
   # Harder case requires handling failures of 1 and or 2, neither implemented
   # 1. different quantiles by key, need to bind the keys, then group_modify
   # 2 fails. need to bind the keys, grab, y and yhat, subtract
-  if (nonneg)
+  if (nonneg) {
     q <- dplyr::mutate(q, dplyr::across(dplyr::everything(), ~ pmax(.x, 0)))
+  }
 
   return(
     dplyr::bind_cols(distinct_keys, q) %>%
@@ -80,12 +83,11 @@ arx_forecaster <- function(x, y, key_vars, time_value,
 #' arx_args_list()
 #' arx_args_list(symmetrize = FALSE)
 #' arx_args_list(levels = c(.1, .3, .7, .9), min_train_window = 120)
-arx_args_list <- function(
-  lags = c(0, 7, 14), ahead = 7, min_train_window = 20,
-  levels = c(0.05, 0.95), intercept = TRUE,
-  symmetrize = TRUE,
-  nonneg = TRUE,
-  quantile_by_key = FALSE) {
+arx_args_list <- function(lags = c(0, 7, 14), ahead = 7, min_train_window = 20,
+                          levels = c(0.05, 0.95), intercept = TRUE,
+                          symmetrize = TRUE,
+                          nonneg = TRUE,
+                          quantile_by_key = FALSE) {
 
   # error checking if lags is a list
   .lags <- lags
@@ -94,13 +96,15 @@ arx_args_list <- function(
   arg_is_scalar(ahead, min_train_window)
   arg_is_nonneg_int(ahead, min_train_window, lags)
   arg_is_lgl(intercept, symmetrize, nonneg)
-  arg_is_probabilities(levels, allow_null=TRUE)
+  arg_is_probabilities(levels, allow_null = TRUE)
 
   max_lags <- max(lags)
 
-  list(lags = .lags, ahead = as.integer(ahead),
-       min_train_window = min_train_window,
-       levels = levels, intercept = intercept,
-       symmetrize = symmetrize, nonneg = nonneg,
-       max_lags = max_lags)
+  list(
+    lags = .lags, ahead = as.integer(ahead),
+    min_train_window = min_train_window,
+    levels = levels, intercept = intercept,
+    symmetrize = symmetrize, nonneg = nonneg,
+    max_lags = max_lags
+  )
 }

--- a/R/knn_iterative_ar_forecaster.R
+++ b/R/knn_iterative_ar_forecaster.R
@@ -1,0 +1,187 @@
+#' KNN enhanced iterative AR forecaster with optional covariates
+#'
+#' @param x Unused covariates. Must to be missing (resulting in AR on `y`) .
+#' @param y Response.
+#' @param key_vars Factor(s). A prediction will be made for each unique
+#'   combination.
+#' @param time_value the time value associated with each row of measurements.
+#' @param args Additional arguments specifying the forecasting task. Created
+#'   by calling `knn_iteraive_ar_args_list()`.
+#'
+#' @return A data frame of point (and optionally interval) forecasts at multiple
+#'   aheads (multiple horizons from one to specified `ahead`) for each unique combination of `key_vars`.
+#' @export
+
+knn_iteraive_ar_forecaster <- function(x, y, key_vars, time_value,
+                                       args = knn_iteraive_ar_args_list()) {
+
+  # TODO: function to verify standard forecaster signature inputs
+  assign_arg_list(args)
+  if (is.null(key_vars)) { # this is annoying/repetitive, seemingly necessary?
+    keys <- NULL
+    distinct_keys <- tibble(.dump = NA)
+  } else {
+    keys <- tibble::tibble(key_vars)
+    distinct_keys <- dplyr::distinct(keys)
+  }
+  if (!is.null(x)) warning("The current version for KNN enhanced iterative forecasting strategy does not support covariates. 'x' will not be used!")
+
+
+  # generate data
+  pool <- create_lags_and_leads(NULL, y, c(1:query_window_len), 1:ahead, time_value, keys)
+  # Return NA if insufficient training data
+  if (nrow(pool) < topK) {
+    qnames <- probs_to_string(levels)
+    out <- dplyr::bind_cols(distinct_keys, point = NA) %>%
+      dplyr::select(!dplyr::any_of(".dump"))
+    return(enframer(out, qnames))
+  }
+  # get test data
+  time_keys <- data.frame(keys, time_value)
+  test_time_value <- max(time_value)
+  common_names <- names(time_keys)
+  key_names <- setdiff(common_names, "time_value")
+  Querys <- dplyr::left_join(time_keys, pool, by = common_names) %>%
+    dplyr::group_by(dplyr::across(dplyr::all_of(key_names))) %>%
+    tidyr::fill(dplyr::starts_with("x")) %>%
+    dplyr::filter(time_value == test_time_value) %>%
+    select(!dplyr::starts_with("y")) %>%
+    drop_na()
+
+  # embed querys and pool
+  pool_raw <- pool
+  pool <- pool %>%
+    select(common_names, dplyr::starts_with("x"), "y1") %>%
+    drop_na()
+  pool_idx <- pool[common_names]
+
+  Querys_idx <- Querys[common_names]
+  pool_emb <- embedding(pool %>% select(-common_names, -dplyr::starts_with("y")))
+  # iterative prediction procedure
+
+  tmp <- data.frame()
+  for (i in 1:nrow(Querys)) {
+    query <- as.numeric(Querys[i, -c(1:2)])
+
+    for (h in 1:ahead) {
+      if (h == 1 | update_model) {
+        query_emb <- embedding(t(query))[1, ]
+        sims <- pool_emb %*% query_emb
+        topk_id <- tensr:::topK(sims, topK)
+        train_id <- pool_idx[topk_id, ]
+        train_da <- train_id %>%
+          left_join(pool, by = common_names) %>%
+          select("y1", paste("x", lags, sep = ""))
+
+        if (intercept) train_da$x0 <- 1
+        obj <- stats::lm(
+          y1 ~ . + 0,
+          data = train_da
+        )
+      }
+
+      test_da <- data.frame(t(query[lags]))
+      names(test_da) <- paste("x", lags, sep = "")
+      if (intercept) test_da$x0 <- 1
+      point <- stats::predict(obj, test_da)
+
+      yname <- paste("y", h, sep = "")
+      residual_pool <- pool_raw %>%
+        select(common_names, dplyr::starts_with("x"), yname) %>%
+        drop_na()
+      residual_pool_emb <- embedding(residual_pool %>% select(-common_names, -yname))
+      sims <- residual_pool_emb %*% query_emb
+      topk_id <- tensr:::topK(sims, topK)
+
+      residual_da <- residual_pool[topk_id, ]
+      gty <- residual_da[yname]
+      residual_da <- residual_pool[topk_id, ] %>%
+        select(-common_names, -yname) %>%
+        as.matrix()
+      for (j in 1:h) {
+        residual_tmp <- data.frame(residual_da[, lags])
+        names(residual_tmp) <- paste("x", lags, sep = "")
+        if (intercept) residual_tmp$x0 <- 1
+        pred <- stats::predict(obj, residual_tmp)
+        residual_da <- cbind(pred, residual_da[, -query_window_len])
+      }
+
+      r <- (gty - pred)[, 1] / pred
+      r[is.na(r)] <- 0
+      q <- residual_quantiles_normlized(r, point, levels, symmetrize)
+      q <- cbind(Querys_idx[i, key_names], q)
+      q$ahead <- h
+      tmp <- bind_rows(tmp, q)
+
+      query <- c(point, query[-query_window_len])
+    }
+  }
+  if (nonneg) {
+    tmp <- dplyr::mutate(tmp, dplyr::across(!ahead, ~ pmax(.x, 0)))
+  }
+
+  res <- tmp %>%
+    dplyr::select(!dplyr::any_of(".dump")) %>%
+    dplyr::relocate(ahead)
+  return(res)
+}
+
+
+
+#'KNN enhanced iterative AR forecaster argument constructor
+#'
+#' Constructs a list of arguments for [knn_iteraive_ar_forecaster()].
+#'
+#' @template param-lags
+#' @template param-query_window_len
+#' @template param-topK
+#' @template param-ahead
+#' @template param-min_train_window
+#' @template param-levels
+#' @template param-intercept
+#' @template param-symmetrize
+#' @template param-nonneg
+#' @template param-update_model
+#' @param quantile_by_key Not currently implemented
+#'
+#' @return A list containing updated parameter choices.
+#' @export
+#'
+#' @examples
+#' arx_args_list()
+#' arx_args_list(symmetrize = FALSE)
+#' arx_args_list(levels = c(.1, .3, .7, .9), min_train_window = 120)
+knn_iteraive_ar_args_list <- function(lags = c(0, 7, 14),
+                                      query_window_len = 50,
+                                      topK = 500,
+                                      ahead = 7,
+                                      min_train_window = 20,
+                                      levels = c(0.05, 0.95),
+                                      intercept = TRUE,
+                                      symmetrize = TRUE,
+                                      nonneg = TRUE,
+                                      quantile_by_key = FALSE,
+                                      update_model = TRUE) {
+
+  # error checking if lags is a list
+  .lags <- lags
+  if (is.list(lags)) lags <- unlist(lags)
+
+  arg_is_scalar(ahead, min_train_window, query_window_len, topK)
+  arg_is_nonneg_int(ahead, min_train_window, lags, query_window_len, topK)
+  arg_is_lgl(intercept, symmetrize, nonneg, update_model)
+  arg_is_probabilities(levels, allow_null = TRUE)
+
+  max_lags <- max(lags)
+
+  list(
+    lags = .lags, ahead = as.integer(ahead),
+    query_window_len = query_window_len,
+    topK = topK,
+    min_train_window = min_train_window,
+    levels = levels, intercept = intercept,
+    symmetrize = symmetrize, nonneg = nonneg,
+    max_lags = max_lags,
+    update_model = update_model
+  )
+}

--- a/R/knnarx_forecaster.R
+++ b/R/knnarx_forecaster.R
@@ -1,0 +1,163 @@
+#' KNN enhanced ARX forecaster with optional covariates
+#'
+#' @param x Covariates. Allowed to be missing (resulting in AR on `y`).
+#' @param y Response.
+#' @param key_vars Factor(s). A prediction will be made for each unique
+#'   combination.
+#' @param time_value the time value associated with each row of measurements.
+#' @param args Additional arguments specifying the forecasting task. Created
+#'   by calling `knnarx_args_list()`.
+#'
+#' @return A data frame of point (and optionally interval) forecasts at a single
+#'   ahead (unique horizon) for each unique combination of `key_vars`.
+#' @export
+
+knnarx_forecaster <- function(x, y, key_vars, time_value,
+                              args = knnarx_args_list()) {
+
+  # TODO: function to verify standard forecaster signature inputs
+  assign_arg_list(args)
+  if (is.null(key_vars)) { # this is annoying/repetitive, seemingly necessary?
+    keys <- NULL
+    distinct_keys <- tibble(.dump = NA)
+  } else {
+    keys <- tibble::tibble(key_vars)
+    distinct_keys <- dplyr::distinct(keys)
+  }
+
+
+
+  # generate data
+  dat <- create_lags_and_leads(x, y, lags, ahead, time_value, keys)
+  if (intercept) dat$x0 <- 1
+  pool <- create_lags_and_leads(NULL, y, c(1:query_window_len), ahead, time_value, keys)
+
+  # Return NA if insufficient training data
+  if (nrow(pool) < topK) {
+    qnames <- probs_to_string(levels)
+    out <- dplyr::bind_cols(distinct_keys, point = NA) %>%
+      dplyr::select(!dplyr::any_of(".dump"))
+    return(enframer(out, qnames))
+  }
+
+  # get test data
+  time_keys <- data.frame(keys, time_value)
+  test_time_value <- max(time_value)
+  common_names <- names(time_keys)
+  key_names <- setdiff(common_names, "time_value")
+  PredData <- dplyr::left_join(time_keys, dat, by = common_names) %>%
+    dplyr::group_by(dplyr::across(dplyr::all_of(key_names))) %>%
+    tidyr::fill(dplyr::starts_with("x")) %>%
+    dplyr::filter(time_value == test_time_value)
+
+  Querys <- dplyr::left_join(time_keys, pool, by = common_names) %>%
+    dplyr::group_by(dplyr::across(dplyr::all_of(key_names))) %>%
+    tidyr::fill(dplyr::starts_with("x")) %>%
+    dplyr::filter(time_value == test_time_value) %>%
+    select(!dplyr::starts_with("y")) %>%
+    drop_na()
+
+  # clean training data and pools
+  idxs <- dplyr::inner_join(pool %>% drop_na() %>% select(common_names),
+    dat %>% drop_na() %>% select(common_names),
+    by = common_names
+  )
+  pool <- dplyr::inner_join(idxs,
+    pool,
+    by = common_names
+  ) %>%
+    select(!dplyr::starts_with("y"))
+
+  dat <- dplyr::inner_join(idxs,
+    dat,
+    by = common_names
+  )
+
+  # embed querys and pool
+  pool_idx <- pool[common_names]
+  Querys_idx <- Querys[common_names]
+
+  pool <- embedding(pool[, 3:ncol(pool)])
+  Querys <- embedding(Querys[, 3:ncol(Querys)])
+  sims <- Querys %*% t(pool)
+
+  tmp <- data.frame()
+  for (i in 1:nrow(sims)) {
+    topk_id <- tensr:::topK(sims[i, ], topK)
+    train_id <- pool_idx[topk_id, ]
+    train_da <- train_id %>% left_join(dat, by = common_names)
+    obj <- stats::lm(
+      y1 ~ . + 0,
+      data = train_da %>% dplyr::select(starts_with(c("x", "y")))
+    )
+
+    point <- stats::predict(obj, Querys_idx[i,] %>% left_join(PredData, by = common_names))
+    r <- residuals(obj)
+    q <- residual_quantiles(r, point, levels, symmetrize)
+    tmp <- rbind(tmp, q)
+  }
+
+  if (nonneg) {
+    tmp <- dplyr::mutate(tmp, dplyr::across(dplyr::everything(), ~ pmax(.x, 0)))
+  }
+  return(
+    dplyr::bind_cols(Querys_idx[key_names], tmp) %>%
+      dplyr::select(!dplyr::any_of(".dump"))
+  )
+}
+
+
+
+#'KNN enhanced ARX forecaster argument constructor
+#'
+#' Constructs a list of arguments for [knnarx_forecaster()].
+#'
+#' @template param-lags
+#' @template param-query_window_len
+#' @template param-topK
+#' @template param-ahead
+#' @template param-min_train_window
+#' @template param-levels
+#' @template param-intercept
+#' @template param-symmetrize
+#' @template param-nonneg
+#' @param quantile_by_key Not currently implemented
+#'
+#' @return A list containing updated parameter choices.
+#' @export
+#'
+#' @examples
+#' knnarx_args_list()
+#' knnarx_args_list(symmetrize = FALSE)
+#' knnarx_args_list(levels = c(.1, .3, .7, .9), min_train_window = 120)
+knnarx_args_list <- function(lags = c(0, 7, 14),
+                             query_window_len = 50,
+                             topK = 500,
+                             ahead = 7,
+                             min_train_window = 20,
+                             levels = c(0.05, 0.95), intercept = TRUE,
+                             symmetrize = TRUE,
+                             nonneg = TRUE,
+                             quantile_by_key = FALSE) {
+
+  # error checking if lags is a list
+  .lags <- lags
+  if (is.list(lags)) lags <- unlist(lags)
+
+  arg_is_scalar(ahead, min_train_window,query_window_len,topK)
+  arg_is_nonneg_int(ahead, min_train_window, lags,query_window_len,topK)
+  arg_is_lgl(intercept, symmetrize, nonneg)
+  arg_is_probabilities(levels, allow_null = TRUE)
+
+  max_lags <- max(lags)
+
+  list(
+    lags = .lags, ahead = as.integer(ahead),
+    query_window_len = query_window_len,
+    topK = topK,
+    min_train_window = min_train_window,
+    levels = levels, intercept = intercept,
+    symmetrize = symmetrize, nonneg = nonneg,
+    max_lags = max_lags
+  )
+}

--- a/R/residual_quantiles.R
+++ b/R/residual_quantiles.R
@@ -7,3 +7,15 @@ residual_quantiles <- function(r, point, levels, symmetrize) {
   names(out)[-1] <- probs_to_string(levels)
   out
 }
+
+
+residual_quantiles_normlized <- function(r, point, levels, symmetrize) {
+  # use relative rediduals for sampling
+  # this will help the performance for residuals with different magnitudes
+  if (is.null(levels)) return(data.frame(point = point))
+  s <- ifelse(symmetrize, -1, NA)
+  q <- quantile(c(r, s * r), probs = levels, na.rm = TRUE)
+  out <- data.frame(point = point, outer(point, 1 + q, "*"))
+  names(out)[-1] <- probs_to_string(levels)
+  out
+}

--- a/R/utils_knn.R
+++ b/R/utils_knn.R
@@ -1,0 +1,5 @@
+embedding <- function(dat) {
+  dat <- as.matrix(dat)
+  dat <- dat / sqrt(rowSums(dat^2) + 1e-12)
+  return(dat)
+}

--- a/vignettes/knn-forecasts.Rmd
+++ b/vignettes/knn-forecasts.Rmd
@@ -17,7 +17,6 @@ knitr::opts_chunk$set(
 ```
 
 ```{r pkgs}
-devtools::load_all('.')
 library(epipredict)
 library(epiprocess)
 library(covidcast)

--- a/vignettes/knn-forecasts.Rmd
+++ b/vignettes/knn-forecasts.Rmd
@@ -1,0 +1,301 @@
+---
+title: "KNN AR(X) forecasts"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{KNN AR(X) forecasts}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  warning = FALSE,
+  message = FALSE
+)
+```
+
+```{r pkgs}
+devtools::load_all('.')
+library(epipredict)
+library(epiprocess)
+library(covidcast)
+library(data.table)
+library(dplyr)
+library(tidyr)
+library(ggplot2)
+library(tensr)
+```
+
+
+In this vignette, we explore the KNN enhanced forecasting strategies.
+
+
+## KNN Enhanced Direct ARX Forecastor
+
+First, we download the data and process as before (hidden).
+
+
+```{r grab-epi-data, echo=FALSE}
+theme_set(theme_bw())
+# y <- covidcast_signals(
+#   c("doctor-visits", "jhu-csse"),
+#   c("smoothed_adj_cli", "confirmed_7dav_incidence_prop"),
+#   start_day = "2020-06-01", 
+#   end_day = "2021-12-01",
+#   issues = c("2020-06-01", "2021-12-01"),
+#   geo_type = "state", 
+#   geo_values = c("ca", "fl")) 
+# saveRDS(y, "inst/extdata/epi_archive.rds")
+y <- readRDS(
+  system.file("extdata", "us_full_data.RData", package = "epipredict", mustWork = TRUE)
+)
+STATES <- c('ga', 'nh', 'va', 'ar', 'az', 'in',
+           'oh', 'hi', 'al', 'nj', 'ma', 'ok',
+           'wa', 'nd', 'sd', 'wy', 'ne', 'nm',
+           'mi', 'la', 'ut', 'pa', 'ky', 'ia',
+           'de', 'mt', 'tn', 'md', 'sc', 'ks',
+           'me', 'ri', 'mn', 'il', 'co', 'tx',
+           'ny', 'dc', 'mo', 'nc', 'ms', 'or',
+           'wi', 'id', 'ak', 'ca', 'ct', 'fl',
+           'nv', 'wv', 'vt')
+x <- y[[1]] %>%  
+  select(geo_value, time_value, version = issue, percent_cli = value) %>%
+  filter(geo_value %in% STATES) %>%
+  as_epi_archive()
+
+epix_merge(
+  x, y[[2]] %>% 
+    select(geo_value, time_value, version = issue, case_rate = value) %>%
+    filter(geo_value %in% STATES) %>%
+    as_epi_archive(),
+  all = TRUE)
+```
+
+We now make forecasts on the archive and compare to forecasts on the latest
+data. 
+
+```{r make-knnarx-kweek}
+# Latest snapshot of data, and forecast dates
+x_latest <- epix_as_of(x, max_version = max(x$DT$version))
+fc_time_values <- seq(as.Date("2020-10-01"), as.Date("2021-12-01"), 
+                      by = "1 month")
+
+
+k_week_ahead <- function(ahead = 7, as_of = TRUE) {
+  if (as_of) {
+    x %>%
+      epix_slide(fc = knnarx_forecaster(
+        percent_cli, case_rate, geo_value, time_value, 
+        args = knnarx_args_list(ahead = ahead,
+                      lags = c(1,7,14),
+                      query_window_len = 32,
+                      topK = 1000,
+                      intercept = FALSE)),
+        n = Inf, ref_time_values = fc_time_values) %>%
+      mutate(target_date = time_value + ahead, as_of = as_of,
+             geo_value = fc_key_vars)
+  } else {
+    x_latest %>%
+      epi_slide(fc = knnarx_forecaster(
+        percent_cli, case_rate, geo_value, time_value,
+        args = knnarx_args_list(ahead = ahead,
+                      lags = c(1,7,14),
+                      query_window_len = 32,
+                      topK = 1000,
+                       intercept = FALSE)),
+        n = Inf, ref_time_values = fc_time_values) %>%
+      mutate(target_date = time_value + ahead, as_of = as_of)
+  }
+}
+
+# Generate the forecasts, and bind them together
+fc <- bind_rows(
+  purrr::map_dfr(c(7,14,21,28), ~ k_week_ahead(.x, as_of = TRUE)),
+  purrr::map_dfr(c(7,14,21,28), ~ k_week_ahead(.x, as_of = FALSE))
+)
+```
+
+
+
+```{r plot-smooth, message = FALSE, warning = FALSE, fig.width = 9, fig.height = 18}
+ggplot(fc %>% filter(as_of == TRUE), aes(x = target_date, group = time_value)) +
+  geom_vline(aes(xintercept = time_value), linetype = 2, alpha = 0.5) +
+  geom_line(data = x_latest, aes(x = time_value, y = case_rate),
+            inherit.aes = FALSE, color = "gray50") +
+  geom_ribbon(aes(ymin = fc_q0.05, ymax = fc_q0.95, fill = geo_value), alpha = 0.4) +
+  geom_line(aes(y = fc_point)) +
+  geom_point(aes(y = fc_point), size = 0.5) +
+  facet_wrap(~ geo_value, ncol = 4, scales = "free_y") +
+  scale_x_date(minor_breaks = "month", date_labels = "%b %y") +
+  labs(x = "Date", y = "Reported COVID-19 case rates") +
+  theme(legend.position = "none")
+```
+
+## KNN Enhanced Iterative AR Forecastor
+
+For the moment, the KNN Enhanced iterative forecasting strategy only support the AR forecastor, which means it can only deal with one signal each time. Same as the direct example, the following pipeline run predictions with the iterative forecasting strategy.
+
+```{r make-iterative-knnar-kweek, message = FALSE, warning = FALSE, fig.width = 9, fig.height = 18}
+ahead <- 21
+final_iterative <- x %>%
+  epix_slide(
+    fc = knn_iteraive_ar_forecaster(
+      NULL, case_rate, geo_value, time_value,
+      args = knn_iteraive_ar_args_list(
+        ahead = ahead,
+        lags = c(1, 7, 14),
+        query_window_len = 32,
+        topK = 1000,
+        symmetrize = FALSE,
+        update_model = FALSE
+      )
+    ) %>% nest_by(key_vars),
+    n = Inf, ref_time_values = fc_time_values
+  ) %>% unnest(fc_data) %>% 
+  mutate(target_date = time_value + ahead, as_of = TRUE) %>%
+  rename(geo_value = fc_key_vars)
+
+ggplot(final_iterative, aes(x = target_date, group = time_value)) +
+  geom_vline(aes(xintercept = time_value), linetype = 2, alpha = 0.5) +
+  geom_line(data = x_latest  , aes(x = time_value, y = case_rate),
+            inherit.aes = FALSE, color = "gray50") +
+  geom_ribbon(aes(ymin = q0.05, ymax = q0.95, fill = geo_value), alpha = 0.4) +
+  geom_line(aes(y = point)) +
+  geom_point(aes(y = point), size = 0.5) +
+  facet_wrap(~ geo_value, ncol = 4, scales = "free_y") +
+  scale_x_date(minor_breaks = "month", date_labels = "%b %y") +
+  labs(x = "Date", y = "Reported COVID-19 case rates") +
+  theme(legend.position = "none")
+```
+
+
+
+The `update_model` parameter in the iterative forecastor API decides if the one-step ahead model will be updated or not during the iterative predicting procedure. The following pipeline shows the results with this trigger turned on.
+
+```{r make-dynamiciterative-knnar-kweek, message = FALSE, warning = FALSE, fig.width = 9, fig.height = 18}
+final_dynamiciterative <- x %>%
+  epix_slide(
+    fc = knn_iteraive_ar_forecaster(
+      NULL, case_rate, geo_value, time_value,
+      args = knn_iteraive_ar_args_list(
+        ahead = ahead,
+        lags = c(1, 7, 14),
+        query_window_len = 32,
+        topK = 1000,
+        symmetrize = FALSE,
+        update_model = TRUE
+      )
+    ) %>% nest_by(key_vars),
+    n = Inf, ref_time_values = fc_time_values
+  ) %>% unnest(fc_data) %>% 
+  mutate(target_date = time_value + ahead, as_of = TRUE) %>%
+  rename(geo_value = fc_key_vars)
+
+ggplot(final_dynamiciterative, aes(x = target_date, group = time_value)) +
+  geom_vline(aes(xintercept = time_value), linetype = 2, alpha = 0.5) +
+  geom_line(data = x_latest  , aes(x = time_value, y = case_rate),
+            inherit.aes = FALSE, color = "gray50") +
+  geom_ribbon(aes(ymin = q0.05, ymax = q0.95, fill = geo_value), alpha = 0.4) +
+  geom_line(aes(y = point)) +
+  geom_point(aes(y = point), size = 0.5) +
+  facet_wrap(~ geo_value, ncol = 4, scales = "free_y") +
+  scale_x_date(minor_breaks = "month", date_labels = "%b %y") +
+  labs(x = "Date", y = "Reported COVID-19 case rates") +
+  theme(legend.position = "none")
+```
+
+
+## Using data for Canada
+
+By leveraging the flexibility of `epiprocess`, we can apply the same techniques to data from other sources. Since I'm in British Columbia, may as well do the same thing for Canada.
+
+The [COVID-19 Canada Open Data Working Group](https://opencovid.ca/) collects daily time series data on COVID-19 cases, deaths, recoveries, testing and vaccinations at the health region and province levels. Data are collected from publicly available sources such as government datasets and news releases. Unfortunately, there is no simple versioned source, so we have created our own from the Commit history.
+
+First, we load versioned case numbers at the provincial level, and convert these to an `epi_archive` object. Then we run a very similar forcasting exercise as that above.
+
+```{r get-can-fc}
+# source("drafts/canada-case-rates.R)
+can <- readRDS(
+  system.file("extdata", "can_prov_cases.rds", 
+              package = "epipredict", mustWork = TRUE)
+  ) %>%
+  group_by(version, geo_value) %>% 
+  arrange(time_value) %>% 
+  mutate(cr_7dav = RcppRoll::roll_meanr(case_rate, n = 7L))
+
+can <- as_epi_archive(can)
+can_latest <- epix_as_of(can, max_version = max(can$DT$version))
+can_fc_time_values = seq(as.Date("2020-10-01"), as.Date("2021-11-01"), 
+                      by = "1 month")
+
+can_k_week_ahead <- function(ahead = 7, as_of = TRUE) {
+  if (as_of) {
+    can %>%
+      epix_slide(fc = knnarx_forecaster(
+        y = cr_7dav, key_vars = geo_value, time_value = time_value,
+        args =knnarx_args_list(ahead = ahead,
+                      lags = c(1,7,14),
+                      query_window_len = 32,
+                      topK = 200)),
+        n = Inf, ref_time_values = fc_time_values) %>%
+      mutate(target_date = time_value + ahead, geo_value = fc_key_vars,
+             as_of = as_of)
+  } else {
+    can_latest %>%
+      epi_slide(fc = knnarx_forecaster(
+        y = cr_7dav, key_vars = geo_value, time_value = time_value,
+        args = knnarx_args_list(ahead = ahead,
+                      lags = c(1,7,14),
+                      query_window_len = 32,
+                      topK = 300)),
+        n = Inf, ref_time_values = fc_time_values) %>%
+      mutate(target_date = time_value + ahead, geo_value = fc_key_vars,
+             as_of = as_of)
+  }
+}
+
+can_fc <- bind_rows(
+  purrr:::map_dfr(c(7,14,21,28), ~ can_k_week_ahead(ahead = .x, as_of = TRUE)),
+  purrr:::map_dfr(c(7,14,21,28), ~ can_k_week_ahead(ahead = .x, as_of = FALSE))
+)
+```
+
+The figures below shows the results for all of the provinces. Note that we are showing the 7-day averages rather than the reported case numbers due to highly variable provincial reporting mismatches.
+
+
+```{r plot-can-fc, message = FALSE, warning = FALSE, fig.width = 9, fig.height = 12}
+ggplot(can_fc %>% filter(! as_of), 
+       aes(x = target_date, group = time_value)) +
+  coord_cartesian(xlim = lubridate::ymd(c("2020-12-01", NA))) +
+  geom_line(data = can_latest, aes(x = time_value, y = cr_7dav),
+            inherit.aes = FALSE, color = "gray50") +
+  geom_ribbon(aes(ymin = fc_q0.05, ymax = fc_q0.95, fill = geo_value),
+              alpha = 0.4) +
+  geom_line(aes(y = fc_point)) + geom_point(aes(y = fc_point), size = 0.5) +
+  
+  geom_vline(aes(xintercept = time_value), linetype = 2, alpha = 0.5) +
+  facet_wrap(~geo_value, scales = "free_y", ncol = 3) +
+  scale_x_date(minor_breaks = "month", date_labels = "%b %y") +
+  labs(title = "Finalized data", x = "Date", 
+       y = "Reported COVID-19 case rates") +
+  theme(legend.position = "none")  
+```
+
+```{r plot-can-fc-proper, message = FALSE, warning = FALSE, fig.width = 9, fig.height = 12}
+ggplot(can_fc %>% filter(as_of), 
+       aes(x = target_date, group = time_value)) +
+  coord_cartesian(xlim = lubridate::ymd(c("2020-12-01", NA))) +
+  geom_line(data = can_latest, aes(x = time_value, y = cr_7dav),
+            inherit.aes = FALSE, color = "gray50") +
+  geom_ribbon(aes(ymin = fc_q0.05, ymax = fc_q0.95, fill = geo_value),
+              alpha = 0.4) +
+  geom_line(aes(y = fc_point)) + geom_point(aes(y = fc_point), size = 0.5) +
+  geom_vline(aes(xintercept = time_value), linetype = 2, alpha = 0.5) +
+  facet_wrap(~ geo_value, scales = "free_y", ncol = 3) +
+  scale_x_date(minor_breaks = "month", date_labels = "%b %y") +
+  labs(title = "Properly versioned data", x = "Date", 
+       y = "Reported COVID-19 case rates") +
+  theme(legend.position = "none")  
+```


### PR DESCRIPTION
Hi, @dajmcdon. Those commits add the support for KNN enhanced iterative, dynamic iterative, and direct methods. The direct method support the `arx` mode while the two iterative methods only support the `ar` mode. 

A few comments:
1.  The search-train-predict-residual procedures are tangled together because we need the `new_data` first to start.  Although we can technically split some of them apart, splitting will induce non-trivial space or computation redundancy.
2. `arx_forecastor.R` was accidentally changed when I apply auto formating for the scripts. Those changes can be revoked if needed.
3. KNN searching is supported by package `tensr`. Do we need to manually add it to dependencies?