### PR TITLE
56 convert the tests in layer predict and frosting to documentation ex

### DIFF
--- a/R/frosting.R
+++ b/R/frosting.R
@@ -113,13 +113,16 @@ new_frosting <- function() {
 #' @export
 #'
 #' @examples
+#' library(dplyr)
+#' library(recipes)
+#'
 #' # Toy example to show that frosting can be created and added for postprocessing
 #'  f <- frosting()
 #'  wf <- epi_workflow() %>% add_frosting(f)
 #'
 #' # A more realistic example
 #' jhu <- case_death_rate_subset %>%
-#'   dplyr::filter(time_value > "2021-11-01", geo_value %in% c("ak", "ca", "ny"))
+#'   filter(time_value > "2021-11-01", geo_value %in% c("ak", "ca", "ny"))
 #'
 #' r <- epi_recipe(jhu) %>%
 #'   step_epi_lag(death_rate, lag = c(0, 7, 14)) %>%
@@ -127,7 +130,7 @@ new_frosting <- function() {
 #'   step_naomit(all_predictors()) %>%
 #'   step_naomit(all_outcomes(), skip = TRUE)
 #'
-#' wf <- epi_workflow(r, parsnip::linear_reg()) %>% fit(jhu)
+#' wf <- epi_workflow(r, parsnip::linear_reg()) %>% parsnip::fit(jhu)
 #' latest <- get_test_data(recipe = r, x = jhu)
 #'
 #' f <- frosting() %>%

--- a/R/frosting.R
+++ b/R/frosting.R
@@ -8,7 +8,7 @@
 #' @export
 #'
 #' @examples
-#' #' # Try out frosting validators / constructors
+#' # Try out frosting validators / constructors
 #'  wf <- epi_workflow()
 #' is_frosting(new_frosting()) # should be TRUE
 #'
@@ -33,6 +33,7 @@
 #'  wf <- wf %>% remove_frosting()
 #'  has_postprocessor(wf) # should be FALSE
 #'  has_postprocessor_frosting(wf) # should be FALSE
+#'
 add_frosting <- function(x, frosting, ...) {
   rlang::check_dots_empty()
   action <- workflows:::new_action_post(frosting = frosting)
@@ -112,6 +113,11 @@ new_frosting <- function() {
 #'
 #' @return A frosting object.
 #' @export
+#'
+#' @examples
+#' # Frosting can be created and added for postprocessing
+#'  f <- frosting()
+#'  wf <- epi_workflow() %>% add_frosting(f)
 frosting <- function(layers = NULL, requirements = NULL) {
   if (!is_null(layers) || !is_null(requirements)) {
     rlang::abort(c("Currently, no arguments to `frosting()` are allowed",

--- a/R/frosting.R
+++ b/R/frosting.R
@@ -6,6 +6,33 @@
 #'
 #' @return `x`, updated with a new or removed frosting postprocessor
 #' @export
+#'
+#' @examples
+#' #' # Try out frosting validators / constructors
+#'  wf <- epi_workflow()
+#' is_frosting(new_frosting()) # should be TRUE
+#'
+#'  ## Three ways to add a frosting postprocessor
+#'  wf1 <- epi_workflow(postprocessor = new_frosting())
+#'  has_postprocessor(wf1) # should be TRUE
+#'  has_postprocessor_frosting(wf1) # should be TRUE
+#'
+#'  wf2 <- wf %>% add_postprocessor(new_frosting())
+#'  has_postprocessor(wf2) # should be TRUE
+#'  has_postprocessor_frosting(wf2) # should be TRUE
+#'
+#' wf3 <- wf %>% add_frosting(new_frosting())
+#'  has_postprocessor(wf3) # should be TRUE
+#'  has_postprocessor_frosting(wf3) # should be TRUE
+#'
+#' # Frosting can be created/added/removed
+#'  f <- frosting()
+#'  wf <- epi_workflow() %>% add_frosting(f)
+#' has_postprocessor(wf) # should be TRUE
+#' has_postprocessor_frosting(wf) # should be TRUE
+#'  wf <- wf %>% remove_frosting()
+#'  has_postprocessor(wf) # should be FALSE
+#'  has_postprocessor_frosting(wf) # should be FALSE
 add_frosting <- function(x, frosting, ...) {
   rlang::check_dots_empty()
   action <- workflows:::new_action_post(frosting = frosting)

--- a/R/frosting.R
+++ b/R/frosting.R
@@ -10,18 +10,18 @@
 #' @examples
 #' # Try out frosting validators / constructors
 #'  wf <- epi_workflow()
-#' epipredict:::is_frosting(new_frosting()) # should be TRUE
+#' epipredict:::is_frosting(epipredict:::new_frosting()) # should be TRUE
 #'
 #'  ## Three ways to add a frosting postprocessor
-#'  wf1 <- epi_workflow(postprocessor = new_frosting())
+#'  wf1 <- epi_workflow(postprocessor = epipredict:::new_frosting())
 #'  epipredict:::has_postprocessor(wf1) # should be TRUE
 #'  epipredict:::has_postprocessor_frosting(wf1) # should be TRUE
 #'
-#'  wf2 <- wf %>% epipredict:::add_postprocessor(new_frosting())
+#'  wf2 <- wf %>% epipredict:::add_postprocessor(epipredict:::new_frosting())
 #'  epipredict:::has_postprocessor(wf2) # should be TRUE
 #'  epipredict:::has_postprocessor_frosting(wf2) # should be TRUE
 #'
-#' wf3 <- wf %>% add_frosting(new_frosting())
+#' wf3 <- wf %>% add_frosting(epipredict:::new_frosting())
 #'  epipredict:::has_postprocessor(wf3) # should be TRUE
 #'  epipredict:::has_postprocessor_frosting(wf3) # should be TRUE
 #'

--- a/R/frosting.R
+++ b/R/frosting.R
@@ -10,29 +10,29 @@
 #' @examples
 #' # Try out frosting validators / constructors
 #'  wf <- epi_workflow()
-#' is_frosting(new_frosting()) # should be TRUE
+#' epipredict:::is_frosting(new_frosting()) # should be TRUE
 #'
 #'  ## Three ways to add a frosting postprocessor
 #'  wf1 <- epi_workflow(postprocessor = new_frosting())
-#'  has_postprocessor(wf1) # should be TRUE
-#'  has_postprocessor_frosting(wf1) # should be TRUE
+#'  epipredict:::has_postprocessor(wf1) # should be TRUE
+#'  epipredict:::has_postprocessor_frosting(wf1) # should be TRUE
 #'
-#'  wf2 <- wf %>% add_postprocessor(new_frosting())
-#'  has_postprocessor(wf2) # should be TRUE
-#'  has_postprocessor_frosting(wf2) # should be TRUE
+#'  wf2 <- wf %>% epipredict:::add_postprocessor(new_frosting())
+#'  epipredict:::has_postprocessor(wf2) # should be TRUE
+#'  epipredict:::has_postprocessor_frosting(wf2) # should be TRUE
 #'
 #' wf3 <- wf %>% add_frosting(new_frosting())
-#'  has_postprocessor(wf3) # should be TRUE
-#'  has_postprocessor_frosting(wf3) # should be TRUE
+#'  epipredict:::has_postprocessor(wf3) # should be TRUE
+#'  epipredict:::has_postprocessor_frosting(wf3) # should be TRUE
 #'
 #' # Frosting can be created/added/removed
 #'  f <- frosting()
 #'  wf <- epi_workflow() %>% add_frosting(f)
-#' has_postprocessor(wf) # should be TRUE
-#' has_postprocessor_frosting(wf) # should be TRUE
+#' epipredict:::has_postprocessor(wf) # should be TRUE
+#' epipredict:::has_postprocessor_frosting(wf) # should be TRUE
 #'  wf <- wf %>% remove_frosting()
-#'  has_postprocessor(wf) # should be FALSE
-#'  has_postprocessor_frosting(wf) # should be FALSE
+#'  epipredict:::has_postprocessor(wf) # should be FALSE
+#'  epipredict:::has_postprocessor_frosting(wf) # should be FALSE
 #'
 add_frosting <- function(x, frosting, ...) {
   rlang::check_dots_empty()

--- a/R/layer_predict.R
+++ b/R/layer_predict.R
@@ -15,16 +15,19 @@
 #' @export
 #'
 #' @examples
+#' library(dplyr)
+#' library(recipes)
+#'
 #' jhu <- case_death_rate_subset %>%
-#' dplyr::filter(time_value > "2021-11-01", geo_value %in% c("ak", "ca", "ny"))
+#' filter(time_value > "2021-11-01", geo_value %in% c("ak", "ca", "ny"))
 #' r <- epi_recipe(jhu) %>%
 #'  step_epi_lag(death_rate, lag = c(0, 7, 14)) %>%
 #'  step_epi_ahead(death_rate, ahead = 7) %>%
-#'  recipes::step_naomit(recipes::all_predictors()) %>%
-#'  recipes::step_naomit(recipes::all_outcomes(), skip = TRUE)
+#'  step_naomit(all_predictors()) %>%
+#'  step_naomit(all_outcomes(), skip = TRUE)
 #' wf <- epi_workflow(r, parsnip::linear_reg()) %>% parsnip::fit(jhu)
 #' latest <- jhu %>%
-#'  dplyr::filter(time_value >= max(time_value) - 14)
+#'  filter(time_value >= max(time_value) - 14)
 #'
 #' # Predict layer alone
 #' f <- frosting() %>% layer_predict()

--- a/R/layer_predict.R
+++ b/R/layer_predict.R
@@ -13,6 +13,32 @@
 #'
 #' @return An updated `frosting` object
 #' @export
+#'
+#' @examples
+#' jhu <- case_death_rate_subset %>%
+#' dplyr::filter(time_value > "2021-11-01", geo_value %in% c("ak", "ca", "ny"))
+#' r <- epi_recipe(jhu) %>%
+#'  step_epi_lag(death_rate, lag = c(0, 7, 14)) %>%
+#'  step_epi_ahead(death_rate, ahead = 7) %>%
+#'  recipes::step_naomit(recipes::all_predictors()) %>%
+#'  recipes::step_naomit(recipes::all_outcomes(), skip = TRUE)
+#' wf <- epi_workflow(r, parsnip::linear_reg()) %>% fit(jhu)
+#' latest <- jhu %>%
+#'  dplyr::filter(time_value >= max(time_value) - 14)
+#'
+#' # Predict layer alone
+#' f <- frosting() %>% layer_predict()
+#' wf1 <- wf %>% add_frosting(f)
+#'
+#' p1 <- predict(wf1, latest)
+#' p1
+#'
+#' # Prediction with interval
+#' f <- frosting() %>% layer_predict(type = "pred_int")
+#' wf2 <- wf %>% add_frosting(f)
+#'
+#' p2 <- predict(wf2, latest)
+#' p2
 layer_predict <-
   function(frosting, type = NULL, opts = list(), ..., id = rand_id("predict_default")) {
     add_layer(

--- a/R/layer_predict.R
+++ b/R/layer_predict.R
@@ -22,7 +22,7 @@
 #'  step_epi_ahead(death_rate, ahead = 7) %>%
 #'  recipes::step_naomit(recipes::all_predictors()) %>%
 #'  recipes::step_naomit(recipes::all_outcomes(), skip = TRUE)
-#' wf <- epi_workflow(r, parsnip::linear_reg()) %>% fit(jhu)
+#' wf <- epi_workflow(r, parsnip::linear_reg()) %>% parsnip::fit(jhu)
 #' latest <- jhu %>%
 #'  dplyr::filter(time_value >= max(time_value) - 14)
 #'

--- a/man/add_frosting.Rd
+++ b/man/add_frosting.Rd
@@ -22,3 +22,30 @@ remove_frosting(x)
 \description{
 Add frosting to a workflow
 }
+\examples{
+#' # Try out frosting validators / constructors
+ wf <- epi_workflow()
+is_frosting(new_frosting()) # should be TRUE
+
+ ## Three ways to add a frosting postprocessor
+ wf1 <- epi_workflow(postprocessor = new_frosting())
+ has_postprocessor(wf1) # should be TRUE
+ has_postprocessor_frosting(wf1) # should be TRUE
+
+ wf2 <- wf \%>\% add_postprocessor(new_frosting())
+ has_postprocessor(wf2) # should be TRUE
+ has_postprocessor_frosting(wf2) # should be TRUE
+
+wf3 <- wf \%>\% add_frosting(new_frosting())
+ has_postprocessor(wf3) # should be TRUE
+ has_postprocessor_frosting(wf3) # should be TRUE
+
+# Frosting can be created/added/removed
+ f <- frosting()
+ wf <- epi_workflow() \%>\% add_frosting(f)
+has_postprocessor(wf) # should be TRUE
+has_postprocessor_frosting(wf) # should be TRUE
+ wf <- wf \%>\% remove_frosting()
+ has_postprocessor(wf) # should be FALSE
+ has_postprocessor_frosting(wf) # should be FALSE
+}

--- a/man/add_frosting.Rd
+++ b/man/add_frosting.Rd
@@ -25,18 +25,18 @@ Add frosting to a workflow
 \examples{
 # Try out frosting validators / constructors
  wf <- epi_workflow()
-epipredict:::is_frosting(new_frosting()) # should be TRUE
+epipredict:::is_frosting(epipredict:::new_frosting()) # should be TRUE
 
  ## Three ways to add a frosting postprocessor
- wf1 <- epi_workflow(postprocessor = new_frosting())
+ wf1 <- epi_workflow(postprocessor = epipredict:::new_frosting())
  epipredict:::has_postprocessor(wf1) # should be TRUE
  epipredict:::has_postprocessor_frosting(wf1) # should be TRUE
 
- wf2 <- wf \%>\% epipredict:::add_postprocessor(new_frosting())
+ wf2 <- wf \%>\% epipredict:::add_postprocessor(epipredict:::new_frosting())
  epipredict:::has_postprocessor(wf2) # should be TRUE
  epipredict:::has_postprocessor_frosting(wf2) # should be TRUE
 
-wf3 <- wf \%>\% add_frosting(new_frosting())
+wf3 <- wf \%>\% add_frosting(epipredict:::new_frosting())
  epipredict:::has_postprocessor(wf3) # should be TRUE
  epipredict:::has_postprocessor_frosting(wf3) # should be TRUE
 

--- a/man/add_frosting.Rd
+++ b/man/add_frosting.Rd
@@ -23,30 +23,28 @@ remove_frosting(x)
 Add frosting to a workflow
 }
 \examples{
-# Try out frosting validators / constructors
- wf <- epi_workflow()
-epipredict:::is_frosting(epipredict:::new_frosting()) # should be TRUE
+library(dplyr)
+library(recipes)
 
- ## Three ways to add a frosting postprocessor
- wf1 <- epi_workflow(postprocessor = epipredict:::new_frosting())
- epipredict:::has_postprocessor(wf1) # should be TRUE
- epipredict:::has_postprocessor_frosting(wf1) # should be TRUE
+jhu <- case_death_rate_subset \%>\%
+  filter(time_value > "2021-11-01", geo_value \%in\% c("ak", "ca", "ny"))
+r <- epi_recipe(jhu) \%>\%
+  step_epi_lag(death_rate, lag = c(0, 7, 14)) \%>\%
+  step_epi_ahead(death_rate, ahead = 7) \%>\%
+  step_naomit(all_predictors()) \%>\%
+  step_naomit(all_outcomes(), skip = TRUE)
+wf <- epi_workflow(r, parsnip::linear_reg()) \%>\% parsnip::fit(jhu)
+latest <- jhu \%>\%
+  filter(time_value >= max(time_value) - 14)
 
- wf2 <- wf \%>\% epipredict:::add_postprocessor(epipredict:::new_frosting())
- epipredict:::has_postprocessor(wf2) # should be TRUE
- epipredict:::has_postprocessor_frosting(wf2) # should be TRUE
+# Add frosting to a workflow and predict
+f <- frosting() \%>\% layer_predict() \%>\% layer_naomit(.pred)
+wf1 <- wf \%>\% add_frosting(f)
+p1 <- predict(wf1, latest)
+p1
 
-wf3 <- wf \%>\% add_frosting(epipredict:::new_frosting())
- epipredict:::has_postprocessor(wf3) # should be TRUE
- epipredict:::has_postprocessor_frosting(wf3) # should be TRUE
-
-# Frosting can be created/added/removed
- f <- frosting()
- wf <- epi_workflow() \%>\% add_frosting(f)
-epipredict:::has_postprocessor(wf) # should be TRUE
-epipredict:::has_postprocessor_frosting(wf) # should be TRUE
- wf <- wf \%>\% remove_frosting()
- epipredict:::has_postprocessor(wf) # should be FALSE
- epipredict:::has_postprocessor_frosting(wf) # should be FALSE
-
+# Remove frosting from the workflow and predict
+wf2 <- wf1 \%>\% remove_frosting()
+p2 <- predict(wf2, latest)
+p2
 }

--- a/man/add_frosting.Rd
+++ b/man/add_frosting.Rd
@@ -23,7 +23,7 @@ remove_frosting(x)
 Add frosting to a workflow
 }
 \examples{
-#' # Try out frosting validators / constructors
+# Try out frosting validators / constructors
  wf <- epi_workflow()
 is_frosting(new_frosting()) # should be TRUE
 
@@ -48,4 +48,5 @@ has_postprocessor_frosting(wf) # should be TRUE
  wf <- wf \%>\% remove_frosting()
  has_postprocessor(wf) # should be FALSE
  has_postprocessor_frosting(wf) # should be FALSE
+
 }

--- a/man/add_frosting.Rd
+++ b/man/add_frosting.Rd
@@ -25,28 +25,28 @@ Add frosting to a workflow
 \examples{
 # Try out frosting validators / constructors
  wf <- epi_workflow()
-is_frosting(new_frosting()) # should be TRUE
+epipredict:::is_frosting(new_frosting()) # should be TRUE
 
  ## Three ways to add a frosting postprocessor
  wf1 <- epi_workflow(postprocessor = new_frosting())
- has_postprocessor(wf1) # should be TRUE
- has_postprocessor_frosting(wf1) # should be TRUE
+ epipredict:::has_postprocessor(wf1) # should be TRUE
+ epipredict:::has_postprocessor_frosting(wf1) # should be TRUE
 
- wf2 <- wf \%>\% add_postprocessor(new_frosting())
- has_postprocessor(wf2) # should be TRUE
- has_postprocessor_frosting(wf2) # should be TRUE
+ wf2 <- wf \%>\% epipredict:::add_postprocessor(new_frosting())
+ epipredict:::has_postprocessor(wf2) # should be TRUE
+ epipredict:::has_postprocessor_frosting(wf2) # should be TRUE
 
 wf3 <- wf \%>\% add_frosting(new_frosting())
- has_postprocessor(wf3) # should be TRUE
- has_postprocessor_frosting(wf3) # should be TRUE
+ epipredict:::has_postprocessor(wf3) # should be TRUE
+ epipredict:::has_postprocessor_frosting(wf3) # should be TRUE
 
 # Frosting can be created/added/removed
  f <- frosting()
  wf <- epi_workflow() \%>\% add_frosting(f)
-has_postprocessor(wf) # should be TRUE
-has_postprocessor_frosting(wf) # should be TRUE
+epipredict:::has_postprocessor(wf) # should be TRUE
+epipredict:::has_postprocessor_frosting(wf) # should be TRUE
  wf <- wf \%>\% remove_frosting()
- has_postprocessor(wf) # should be FALSE
- has_postprocessor_frosting(wf) # should be FALSE
+ epipredict:::has_postprocessor(wf) # should be FALSE
+ epipredict:::has_postprocessor_frosting(wf) # should be FALSE
 
 }

--- a/man/epi_workflow.Rd
+++ b/man/epi_workflow.Rd
@@ -11,7 +11,7 @@ epi_workflow(preprocessor = NULL, spec = NULL, postprocessor = NULL)
 \itemize{
 \item A formula, passed on to \code{\link[workflows:add_formula]{add_formula()}}.
 \item A recipe, passed on to \code{\link[workflows:add_recipe]{add_recipe()}}.
-\item A \code{\link[workflows:workflow_variables]{workflow_variables()}} object, passed on to \code{\link[workflows:add_variables]{add_variables()}}.
+\item A \code{\link[workflows:add_variables]{workflow_variables()}} object, passed on to \code{\link[workflows:add_variables]{add_variables()}}.
 }}
 
 \item{spec}{An optional parsnip model specification to add to the workflow.

--- a/man/frosting.Rd
+++ b/man/frosting.Rd
@@ -21,3 +21,8 @@ to hold steps for postprocessing predictions.
 \details{
 The arguments are currently placeholders and must be NULL
 }
+\examples{
+# Frosting can be created/added/removed
+ f <- frosting()
+ wf <- epi_workflow() \%>\% add_frosting(f)
+}

--- a/man/frosting.Rd
+++ b/man/frosting.Rd
@@ -22,7 +22,7 @@ to hold steps for postprocessing predictions.
 The arguments are currently placeholders and must be NULL
 }
 \examples{
-# Frosting can be created/added/removed
+# Frosting can be created and added for postprocessing
  f <- frosting()
  wf <- epi_workflow() \%>\% add_frosting(f)
 }

--- a/man/frosting.Rd
+++ b/man/frosting.Rd
@@ -22,13 +22,16 @@ to hold steps for postprocessing predictions.
 The arguments are currently placeholders and must be NULL
 }
 \examples{
+library(dplyr)
+library(recipes)
+
 # Toy example to show that frosting can be created and added for postprocessing
  f <- frosting()
  wf <- epi_workflow() \%>\% add_frosting(f)
 
 # A more realistic example
 jhu <- case_death_rate_subset \%>\%
-  dplyr::filter(time_value > "2021-11-01", geo_value \%in\% c("ak", "ca", "ny"))
+  filter(time_value > "2021-11-01", geo_value \%in\% c("ak", "ca", "ny"))
 
 r <- epi_recipe(jhu) \%>\%
   step_epi_lag(death_rate, lag = c(0, 7, 14)) \%>\%
@@ -36,7 +39,7 @@ r <- epi_recipe(jhu) \%>\%
   step_naomit(all_predictors()) \%>\%
   step_naomit(all_outcomes(), skip = TRUE)
 
-wf <- epi_workflow(r, parsnip::linear_reg()) \%>\% fit(jhu)
+wf <- epi_workflow(r, parsnip::linear_reg()) \%>\% parsnip::fit(jhu)
 latest <- get_test_data(recipe = r, x = jhu)
 
 f <- frosting() \%>\%

--- a/man/frosting.Rd
+++ b/man/frosting.Rd
@@ -22,7 +22,29 @@ to hold steps for postprocessing predictions.
 The arguments are currently placeholders and must be NULL
 }
 \examples{
-# Frosting can be created and added for postprocessing
+# Toy example to show that frosting can be created and added for postprocessing
  f <- frosting()
  wf <- epi_workflow() \%>\% add_frosting(f)
+
+# A more realistic example
+jhu <- case_death_rate_subset \%>\%
+  dplyr::filter(time_value > "2021-11-01", geo_value \%in\% c("ak", "ca", "ny"))
+
+r <- epi_recipe(jhu) \%>\%
+  step_epi_lag(death_rate, lag = c(0, 7, 14)) \%>\%
+  step_epi_ahead(death_rate, ahead = 7) \%>\%
+  step_naomit(all_predictors()) \%>\%
+  step_naomit(all_outcomes(), skip = TRUE)
+
+wf <- epi_workflow(r, parsnip::linear_reg()) \%>\% fit(jhu)
+latest <- get_test_data(recipe = r, x = jhu)
+
+f <- frosting() \%>\%
+  layer_predict() \%>\%
+  layer_naomit(.pred)
+
+wf1 <- wf \%>\% add_frosting(f)
+
+p <- predict(wf1, latest)
+p
 }

--- a/man/layer_predict.Rd
+++ b/man/layer_predict.Rd
@@ -64,7 +64,7 @@ r <- epi_recipe(jhu) \%>\%
  step_epi_ahead(death_rate, ahead = 7) \%>\%
  recipes::step_naomit(recipes::all_predictors()) \%>\%
  recipes::step_naomit(recipes::all_outcomes(), skip = TRUE)
-wf <- epi_workflow(r, parsnip::linear_reg()) \%>\% fit(jhu)
+wf <- epi_workflow(r, parsnip::linear_reg()) \%>\% parsnip::fit(jhu)
 latest <- jhu \%>\%
  dplyr::filter(time_value >= max(time_value) - 14)
 

--- a/man/layer_predict.Rd
+++ b/man/layer_predict.Rd
@@ -56,6 +56,32 @@ types of prediction, and to potentially apply this after some amount of
 postprocessing. This would typically be the first layer in a \code{frosting}
 postprocessor.
 }
+\examples{
+jhu <- case_death_rate_subset \%>\%
+dplyr::filter(time_value > "2021-11-01", geo_value \%in\% c("ak", "ca", "ny"))
+r <- epi_recipe(jhu) \%>\%
+ step_epi_lag(death_rate, lag = c(0, 7, 14)) \%>\%
+ step_epi_ahead(death_rate, ahead = 7) \%>\%
+ step_naomit(all_predictors()) \%>\%
+ step_naomit(all_outcomes(), skip = TRUE)
+wf <- epi_workflow(r, parsnip::linear_reg()) \%>\% fit(jhu)
+latest <- jhu \%>\%
+ dplyr::filter(time_value >= max(time_value) - 14)
+
+# Predict layer alone
+f <- frosting() \%>\% layer_predict()
+wf1 <- wf \%>\% add_frosting(f)
+
+p1 <- predict(wf1, latest)
+p1
+
+# Prediction with interval
+f <- frosting() \%>\% layer_predict(type = "pred_int")
+wf2 <- wf \%>\% add_frosting(f)
+
+p2 <- predict(wf2, latest)
+p2
+}
 \seealso{
 \code{parsnip::predict.model_fit()}
 }

--- a/man/layer_predict.Rd
+++ b/man/layer_predict.Rd
@@ -57,16 +57,19 @@ postprocessing. This would typically be the first layer in a \code{frosting}
 postprocessor.
 }
 \examples{
+library(dplyr)
+library(recipes)
+
 jhu <- case_death_rate_subset \%>\%
-dplyr::filter(time_value > "2021-11-01", geo_value \%in\% c("ak", "ca", "ny"))
+filter(time_value > "2021-11-01", geo_value \%in\% c("ak", "ca", "ny"))
 r <- epi_recipe(jhu) \%>\%
  step_epi_lag(death_rate, lag = c(0, 7, 14)) \%>\%
  step_epi_ahead(death_rate, ahead = 7) \%>\%
- recipes::step_naomit(recipes::all_predictors()) \%>\%
- recipes::step_naomit(recipes::all_outcomes(), skip = TRUE)
+ step_naomit(all_predictors()) \%>\%
+ step_naomit(all_outcomes(), skip = TRUE)
 wf <- epi_workflow(r, parsnip::linear_reg()) \%>\% parsnip::fit(jhu)
 latest <- jhu \%>\%
- dplyr::filter(time_value >= max(time_value) - 14)
+ filter(time_value >= max(time_value) - 14)
 
 # Predict layer alone
 f <- frosting() \%>\% layer_predict()

--- a/man/layer_predict.Rd
+++ b/man/layer_predict.Rd
@@ -62,8 +62,8 @@ dplyr::filter(time_value > "2021-11-01", geo_value \%in\% c("ak", "ca", "ny"))
 r <- epi_recipe(jhu) \%>\%
  step_epi_lag(death_rate, lag = c(0, 7, 14)) \%>\%
  step_epi_ahead(death_rate, ahead = 7) \%>\%
- step_naomit(all_predictors()) \%>\%
- step_naomit(all_outcomes(), skip = TRUE)
+ recipes::step_naomit(recipes::all_predictors()) \%>\%
+ recipes::step_naomit(recipes::all_outcomes(), skip = TRUE)
 wf <- epi_workflow(r, parsnip::linear_reg()) \%>\% fit(jhu)
 latest <- jhu \%>\%
  dplyr::filter(time_value >= max(time_value) - 14)


### PR DESCRIPTION
As per [Issue 56](https://github.com/cmu-delphi/epipredict/issues/56), converted the tests for `layer_predict()` and for `frosting()` to some examples in the documentation.