### PR TITLE
bump hardhat dependency, removes bake_dependent_roles.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     fs,
     generics,
     glue,
-    hardhat (>= 1.0.0.9000),
+    hardhat (>= 1.1.0.9000),
     magrittr,
     purrr,
     recipes (>= 0.2.0.9001),

--- a/R/blueprint-epi_recipe-default.R
+++ b/R/blueprint-epi_recipe-default.R
@@ -12,13 +12,12 @@
 #' @export
 new_epi_recipe_blueprint <-
   function(intercept = FALSE, allow_novel_levels = FALSE, fresh = TRUE,
-           bake_dependent_roles = character(), composition = "tibble",
+           composition = "tibble",
            ptypes = NULL, recipe = NULL, ..., subclass = character()) {
   hardhat::new_recipe_blueprint(
     intercept = intercept,
     allow_novel_levels = allow_novel_levels,
     fresh = fresh,
-    bake_dependent_roles = c(bake_dependent_roles, "time_value", "geo_value", "key", "raw"),
     composition = composition,
     ptypes = ptypes,
     recipe = recipe,
@@ -32,12 +31,11 @@ new_epi_recipe_blueprint <-
 #' @export
 epi_recipe_blueprint <-
   function(intercept = FALSE, allow_novel_levels = FALSE,
-           fresh = TRUE, bake_dependent_roles = character(),
+           fresh = TRUE,
            composition = "tibble") {
     new_epi_recipe_blueprint(intercept = intercept,
                              allow_novel_levels = allow_novel_levels,
                              fresh = fresh,
-                             bake_dependent_roles = bake_dependent_roles,
                              composition = composition)
   }
 
@@ -45,12 +43,11 @@ epi_recipe_blueprint <-
 #' @export
 default_epi_recipe_blueprint <-
   function(intercept = FALSE, allow_novel_levels = FALSE, fresh = TRUE,
-           bake_dependent_roles = character(), composition = "tibble") {
+           composition = "tibble") {
     new_default_epi_recipe_blueprint(
       intercept = intercept,
       allow_novel_levels = allow_novel_levels,
       fresh = fresh,
-      bake_dependent_roles = bake_dependent_roles,
       composition = composition
     )
   }
@@ -60,14 +57,13 @@ default_epi_recipe_blueprint <-
 #' @export
 new_default_epi_recipe_blueprint <-
   function(intercept = FALSE, allow_novel_levels = FALSE,
-           fresh = TRUE, bake_dependent_roles = character(),
+           fresh = TRUE,
            composition = "tibble", ptypes = NULL, recipe = NULL,
            extra_role_ptypes = NULL, ..., subclass = character()) {
   new_epi_recipe_blueprint(
     intercept = intercept,
     allow_novel_levels = allow_novel_levels,
     fresh = fresh,
-    bake_dependent_roles = bake_dependent_roles,
     composition = composition,
     ptypes = ptypes,
     recipe = recipe,
@@ -81,7 +77,7 @@ new_default_epi_recipe_blueprint <-
 #' @export
 run_mold.default_epi_recipe_blueprint <- function(blueprint, ..., data) {
   rlang::check_dots_empty0(...)
-  blueprint <- hardhat:::patch_recipe_default_blueprint(blueprint)
+  # blueprint <- hardhat:::patch_recipe_default_blueprint(blueprint)
   cleaned <- mold_epi_recipe_default_clean(blueprint = blueprint, data = data)
   blueprint <- cleaned$blueprint
   data <- cleaned$data

--- a/man/new_epi_recipe_blueprint.Rd
+++ b/man/new_epi_recipe_blueprint.Rd
@@ -11,7 +11,6 @@ new_epi_recipe_blueprint(
   intercept = FALSE,
   allow_novel_levels = FALSE,
   fresh = TRUE,
-  bake_dependent_roles = character(),
   composition = "tibble",
   ptypes = NULL,
   recipe = NULL,
@@ -23,7 +22,6 @@ epi_recipe_blueprint(
   intercept = FALSE,
   allow_novel_levels = FALSE,
   fresh = TRUE,
-  bake_dependent_roles = character(),
   composition = "tibble"
 )
 
@@ -31,7 +29,6 @@ default_epi_recipe_blueprint(
   intercept = FALSE,
   allow_novel_levels = FALSE,
   fresh = TRUE,
-  bake_dependent_roles = character(),
   composition = "tibble"
 )
 
@@ -39,7 +36,6 @@ new_default_epi_recipe_blueprint(
   intercept = FALSE,
   allow_novel_levels = FALSE,
   fresh = TRUE,
-  bake_dependent_roles = character(),
   composition = "tibble",
   ptypes = NULL,
   recipe = NULL,
@@ -59,19 +55,6 @@ prediction time? This information is used by the \code{clean} function in the
 
 \item{fresh}{Should already trained operations be re-trained when \code{prep()} is
 called?}
-
-\item{bake_dependent_roles}{A character vector of recipes column "roles"
-specifying roles that are required to \code{\link[recipes:bake]{recipes::bake()}} new data. Can't be
-\code{"predictor"} or \code{"outcome"}, as predictors are always required and
-outcomes are handled by the \code{outcomes} argument of \code{\link[hardhat:forge]{forge()}}.
-
-Typically, non-standard roles (such as \code{"id"} or \code{"case_weights"}) are not
-required to \code{bake()} new data. Unless specified by \code{bake_dependent_roles},
-these non-standard role columns are excluded from checks done in \code{\link[hardhat:forge]{forge()}}
-to validate the column structure of \code{new_data}, will not be passed to
-\code{bake()} even if they existed in \code{new_data}, and will not be returned in
-the \code{forge()$extras$roles} slot. See the documentation of
-\code{\link[recipes:roles]{recipes::add_role()}} for more information about roles.}
 
 \item{composition}{Either "tibble", "matrix", or "dgCMatrix" for the format
 of the processed predictors. If "matrix" or "dgCMatrix" are chosen, all of


### PR DESCRIPTION
As best as I can tell, all our custom roles are now kept around by default rather than the previous runaround where they could be dropped in the bake step.

This is a hotfix to pass checks.