### PR TITLE
Import MatrixModels >= 0.5-1 to avoid subclass warnings/issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Imports:
     glue,
     hardhat (>= 1.2.0),
     magrittr,
+    MatrixModels (>= 0.5-1),
     methods,
     quantreg,
     recipes (>= 1.0.0),


### PR DESCRIPTION
Resolves #157.  It's not immediately clear why, though, as MatrixModels 0.5-1 [doesn't seem](https://github.com/cran/MatrixModels/commit/b92ee8406018beaa4fdf6fba64770c9ff9737ef6) to directly touch the subclasses in the complaint; there may be some more complicated subclass chains involved.  However, I have tested that the warning in #157 does occur with 0.5-0 and does not with 0.5-1, and that this DESCRIPTION file change does indeed result in `remotes::load_all()` noting the requirement and asking to install the newer version (at least when pak is installed), despite whatever complexities were going on with pkgload/renv/pak on my system.  (And `options(warn=2L)` is not required for this update request to occur.)