### PR TITLE
Tidy hotfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     fs,
     generics,
     glue,
-    hardhat (>= 1.2.0),
+    hardhat (>= 1.3.0),
     magrittr,
     methods,
     quantreg,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     magrittr,
     methods,
     quantreg,
-    recipes (>= 1.0.0),
+    recipes (>= 1.0.4),
     rlang,
     stats,
     tibble,

--- a/R/blueprint-epi_recipe-default.R
+++ b/R/blueprint-epi_recipe-default.R
@@ -99,12 +99,12 @@ refresh_blueprint.default_epi_recipe_blueprint <- function(blueprint) {
 
 
 ## removing this function?
-er_check_is_data_like <- function(.x, .x_nm) {
-  if (rlang::is_missing(.x_nm)) {
-    .x_nm <- rlang::as_label(rlang::enexpr(.x))
-  }
-  if (!hardhat:::is_new_data_like(.x)) {
-    hardhat:::glubort("`{.x_nm}` must be a data.frame or a matrix, not a {class1(.x)}.")
-  }
-  .x
-}
+# er_check_is_data_like <- function(.x, .x_nm) {
+#   if (rlang::is_missing(.x_nm)) {
+#     .x_nm <- rlang::as_label(rlang::enexpr(.x))
+#   }
+#   if (!hardhat:::is_new_data_like(.x)) {
+#     hardhat:::glubort("`{.x_nm}` must be a data.frame or a matrix, not a {class1(.x)}.")
+#   }
+#   .x
+# }

--- a/R/blueprint-epi_recipe-default.R
+++ b/R/blueprint-epi_recipe-default.R
@@ -86,7 +86,8 @@ run_mold.default_epi_recipe_blueprint <- function(blueprint, ..., data) {
 }
 
 mold_epi_recipe_default_clean <- function(blueprint, data) {
-  data <- er_check_is_data_like(data)
+  hardhat:::check_data_frame_or_matrix(data)
+  if (!is_epi_df(data)) data <- hardhat:::coerce_to_tibble(data)
   hardhat:::new_mold_clean(blueprint, data)
 }
 
@@ -96,6 +97,8 @@ refresh_blueprint.default_epi_recipe_blueprint <- function(blueprint) {
   do.call(new_default_epi_recipe_blueprint, as.list(blueprint))
 }
 
+
+## removing this function?
 er_check_is_data_like <- function(.x, .x_nm) {
   if (rlang::is_missing(.x_nm)) {
     .x_nm <- rlang::as_label(rlang::enexpr(.x))

--- a/tests/testthat/test-blueprint.R
+++ b/tests/testthat/test-blueprint.R
@@ -5,7 +5,7 @@ test_that("epi_recipe blueprint keeps the class, mold works", {
   expect_s3_class(refresh_blueprint(bp), "default_epi_recipe_blueprint")
 
   jhu <- case_death_rate_subset
-  expect_s3_class(er_check_is_data_like(jhu), "epi_df")
+  # expect_s3_class(er_check_is_data_like(jhu), "epi_df")
 
   r <- epi_recipe(jhu) %>%
     step_epi_lag(death_rate, lag = c(0, 7, 14)) %>%


### PR DESCRIPTION
In `hardhat`, The `check_is_data_like()` fun was removed, and replaced with `coerce_to_tibble()` by [PR 227](https://github.com/tidymodels/hardhat/pull/227). This stripped out the `epi_df` class. We avoid that now. Also requires hardhat >= 1.3.0.