### PR TITLE
Update to latest `epidatr` (`fetch_tbl` -> `fetch`)

### DIFF
--- a/data-raw/case_death_rate_subset.R
+++ b/data-raw/case_death_rate_subset.R
@@ -11,7 +11,7 @@ x <- covidcast(
   time_values = epirange(20201231, 20211231),
   geo_values = "*"
 ) %>%
-  fetch_tbl() %>%
+  fetch() %>%
   select(geo_value, time_value, case_rate = value)
 
 y <- covidcast(
@@ -22,7 +22,7 @@ y <- covidcast(
   time_values = epirange(20201231, 20211231),
   geo_values = "*"
 ) %>%
-  fetch_tbl() %>%
+  fetch() %>%
   select(geo_value, time_value, death_rate = value)
 
 case_death_rate_subset <- x %>%

--- a/musings/example-recipe.R
+++ b/musings/example-recipe.R
@@ -12,7 +12,7 @@ x <- covidcast(
   time_values = epirange(20200301, 20211231),
   geo_values = "*"
 ) %>%
-  fetch_tbl() %>%
+  fetch() %>%
   select(geo_value, time_value, case_rate = value)
 
 y <- covidcast(
@@ -23,7 +23,7 @@ y <- covidcast(
   time_values = epirange(20200301, 20211231),
   geo_values = "*"
 ) %>%
-  fetch_tbl() %>%
+  fetch() %>%
   select(geo_value, time_value, death_rate = value)
 
 x <- x %>%

--- a/vignettes/preprocessing-and-models.Rmd
+++ b/vignettes/preprocessing-and-models.Rmd
@@ -68,7 +68,7 @@ x <- covidcast(
   geo_type = "state",
   time_values = epirange(20210604, 20211231),
   geo_values = "ca,fl,tx,ny,nj") %>%
-  fetch_tbl() %>%
+  fetch() %>%
   select(geo_value, time_value, cases = value)
 
 y <- covidcast(
@@ -78,7 +78,7 @@ y <- covidcast(
   geo_type = "state",
   time_values = epirange(20210604, 20211231),
   geo_values = "ca,fl,tx,ny,nj") %>%
-  fetch_tbl() %>%
+  fetch() %>%
   select(geo_value, time_value, deaths = value)
 
 counts_subset <- full_join(x, y, by = c("geo_value", "time_value")) %>%
@@ -249,7 +249,7 @@ behav_ind_mask <- covidcast(
   geo_type = "state",
   time_values = epirange(20210604, 20211231),
   geo_values = "ca,fl,tx,ny,nj")  %>%
-  fetch_tbl() %>%
+  fetch() %>%
   select(geo_value, time_value, masking = value)
 
 behav_ind_distancing <- covidcast(
@@ -259,7 +259,7 @@ behav_ind_distancing <- covidcast(
   geo_type = "state",
   time_values = epirange(20210604, 20211231),
   geo_values = "ca,fl,tx,ny,nj")  %>%
-  fetch_tbl() %>%
+  fetch() %>%
   select(geo_value, time_value, distancing = value) 
 
 pop_dat <- state_census %>% select(abbr, pop)


### PR DESCRIPTION
Resolves breaking change from upstream cmu-delphi/epidatr#99.  We "can't" `>=` the epidatr version dependency to try to get people better error messages because old versions hanging around are tagged "1.0.0" or maybe also "0.5.0", and we don't want to call the new version with this change something > "1.0.0".