### PR TITLE
Change epiprocess@dev to use default, for downstream consistency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,7 +62,7 @@ VignetteBuilder:
     knitr
 Remotes:
     cmu-delphi/epidatr,
-    cmu-delphi/epiprocess@dev,
+    cmu-delphi/epiprocess,
     dajmcdon/smoothqr
 Config/testthat/edition: 3
 Encoding: UTF-8


### PR DESCRIPTION
so that users don't run into errors trying to install epipredict after default (non-dev) epiprocess.