### PR TITLE
Modified `get_test_data()` to omit excess rows when lag != 0

### DIFF
--- a/R/get_test_data.R
+++ b/R/get_test_data.R
@@ -43,6 +43,7 @@ get_test_data <- function(recipe, x, fill_locf = FALSE, n_recent = NULL) {
 
   if (!all(colnames(x) %in% colnames(recipe$template)))
     cli_stop("some variables used for training are not available in `x`.")
+  min_lags <- max(map_dbl(recipe$steps, ~ min(.x$lag %||% 0)), 0)
   max_lags <- max(map_dbl(recipe$steps, ~ max(.x$lag %||% 0)), 0)
   max_horizon <- max(map_dbl(recipe$steps, ~ max(.x$horizon %||% 0)), 0)
   min_required <- max_lags + max_horizon
@@ -59,6 +60,7 @@ get_test_data <- function(recipe, x, fill_locf = FALSE, n_recent = NULL) {
   x <- x %>%
     epiprocess::group_by(dplyr::across(dplyr::all_of(groups))) %>%
     dplyr::slice_tail(n = max(n_recent, min_required + 1))
+  if(min_lags != 0) x <- x %>% slice_head(n = -min_lags)
 
   if (fill_locf) {
     cannot_be_used <- x %>%

--- a/R/layer_population_scaling.R
+++ b/R/layer_population_scaling.R
@@ -58,7 +58,7 @@
 #'                           df_pop_col = "value",
 #'                           by = c("geo_value" = "states"),
 #'                           cases, suffix = "_scaled") %>%
-#'   step_epi_lag(cases_scaled, lag = c(7, 14)) %>%
+#'   step_epi_lag(cases_scaled, lag = c(0, 7, 14)) %>%
 #'   step_epi_ahead(cases_scaled, ahead = 7, role = "outcome") %>%
 #'   step_epi_naomit()
 #'

--- a/R/step_population_scaling.R
+++ b/R/step_population_scaling.R
@@ -76,7 +76,7 @@
 #'                           df_pop_col = "value",
 #'                           by = c("geo_value" = "states"),
 #'                           cases, suffix = "_scaled") %>%
-#'   step_epi_lag(cases_scaled, lag = c(7, 14)) %>%
+#'   step_epi_lag(cases_scaled, lag = c(0, 7, 14)) %>%
 #'   step_epi_ahead(cases_scaled, ahead = 7, role = "outcome") %>%
 #'   step_epi_naomit()
 #'

--- a/man/layer_population_scaling.Rd
+++ b/man/layer_population_scaling.Rd
@@ -85,7 +85,7 @@ r <- epi_recipe(jhu) \%>\%
                           df_pop_col = "value",
                           by = c("geo_value" = "states"),
                           cases, suffix = "_scaled") \%>\%
-  step_epi_lag(cases_scaled, lag = c(7, 14)) \%>\%
+  step_epi_lag(cases_scaled, lag = c(0, 7, 14)) \%>\%
   step_epi_ahead(cases_scaled, ahead = 7, role = "outcome") \%>\%
   step_epi_naomit()
 

--- a/man/step_population_scaling.Rd
+++ b/man/step_population_scaling.Rd
@@ -111,7 +111,7 @@ r <- epi_recipe(jhu) \%>\%
                           df_pop_col = "value",
                           by = c("geo_value" = "states"),
                           cases, suffix = "_scaled") \%>\%
-  step_epi_lag(cases_scaled, lag = c(7, 14)) \%>\%
+  step_epi_lag(cases_scaled, lag = c(0, 7, 14)) \%>\%
   step_epi_ahead(cases_scaled, ahead = 7, role = "outcome") \%>\%
   step_epi_naomit()
 

--- a/tests/testthat/test-get_test_data.R
+++ b/tests/testthat/test-get_test_data.R
@@ -26,6 +26,7 @@ test_that("expect insufficient training data error", {
   expect_error(get_test_data(recipe = r, x = case_death_rate_subset))
 })
 
+
 test_that("expect error that geo_value or time_value does not exist", {
   r <-  epi_recipe(case_death_rate_subset) %>%
     step_epi_ahead(death_rate, ahead = 7) %>%
@@ -76,4 +77,23 @@ test_that("NA fill behaves as desired", {
  expect_true(!any(is.na(td2)))
 
 
+})
+
+test_that("Omit end rows according to minimum lag when that’s not lag 0", {
+  ca <- case_death_rate_subset %>%
+    filter(geo_value == "ca")
+
+  rec <- epi_recipe(ca) %>%
+    step_epi_lag(case_rate, lag = c(2, 4, 6)) %>%
+    step_epi_ahead(case_rate, ahead = 7) %>%
+    step_epi_naomit()
+
+  td <- get_test_data(rec, ca)
+
+  td_res <- bake(prep(rec, ca), td)
+  td_row1to5_res <-  bake(prep(rec, ca), td[1:5, ])
+
+  expect_equal(td_res, td_row1to5_res)
+  expect_equal(nrow(td_res), 1L)
+  expect_equal(td_res$time_value, as.Date("2021-12-31"))
 })

--- a/tests/testthat/test-get_test_data.R
+++ b/tests/testthat/test-get_test_data.R
@@ -98,10 +98,13 @@ test_that("Omit end rows according to minimum lag when that’s not lag 0", {
 
   toy_td_res <- bake(prep(toy_rec, toy_epi_df), toy_td)
 
+  expect_equal(ncol(toy_td_res), 6L)
   expect_equal(nrow(toy_td_res), 1L)
   expect_equal(toy_td_res$time_value, as.Date("2020-01-10"))
   expect_equal(toy_epi_df[toy_epi_df$time_value == as.Date("2020-01-08"),]$x, toy_td_res$lag_2_x)
   expect_equal(toy_epi_df[toy_epi_df$time_value == as.Date("2020-01-06"),]$x, toy_td_res$lag_4_x)
+  expect_equal(toy_td_res$x, NA_integer_)
+  expect_equal(toy_td_res$ahead_3_x, NA_integer_)
 
   # Ex. using real built-in data
 

--- a/tests/testthat/test-get_test_data.R
+++ b/tests/testthat/test-get_test_data.R
@@ -96,4 +96,7 @@ test_that("Omit end rows according to minimum lag when that’s not lag 0", {
   expect_equal(td_res, td_row1to5_res)
   expect_equal(nrow(td_res), 1L)
   expect_equal(td_res$time_value, as.Date("2021-12-31"))
+  expect_equal(ca[ca$time_value == as.Date("2021-12-29"),]$case_rate, td_res$lag_2_case_rate)
+  expect_equal(ca[ca$time_value == as.Date("2021-12-27"),]$case_rate, td_res$lag_4_case_rate)
+  expect_equal(ca[ca$time_value == as.Date("2021-12-25"),]$case_rate, td_res$lag_6_case_rate)
 })

--- a/tests/testthat/test-get_test_data.R
+++ b/tests/testthat/test-get_test_data.R
@@ -80,6 +80,31 @@ test_that("NA fill behaves as desired", {
 })
 
 test_that("Omit end rows according to minimum lag when that’s not lag 0", {
+  # Simple toy ex
+
+  toy_epi_df <- tibble::tibble(
+    time_value = seq(as.Date("2020-01-01"), by = 1,
+                     length.out = 10),
+    geo_value = "ak",
+    x = 1:10
+  ) %>% epiprocess::as_epi_df()
+
+  toy_rec <- epi_recipe(toy_epi_df) %>%
+    step_epi_lag(x, lag = c(2, 4)) %>%
+    step_epi_ahead(x, ahead = 3) %>%
+    step_epi_naomit()
+
+  toy_td <- get_test_data(toy_rec, toy_epi_df)
+
+  toy_td_res <- bake(prep(toy_rec, toy_epi_df), toy_td)
+
+  expect_equal(nrow(toy_td_res), 1L)
+  expect_equal(toy_td_res$time_value, as.Date("2020-01-10"))
+  expect_equal(toy_epi_df[toy_epi_df$time_value == as.Date("2020-01-08"),]$x, toy_td_res$lag_2_x)
+  expect_equal(toy_epi_df[toy_epi_df$time_value == as.Date("2020-01-06"),]$x, toy_td_res$lag_4_x)
+
+  # Ex. using real built-in data
+
   ca <- case_death_rate_subset %>%
     filter(geo_value == "ca")
 

--- a/tests/testthat/test-population_scaling.R
+++ b/tests/testthat/test-population_scaling.R
@@ -112,7 +112,7 @@ test_that("Postprocessing workflow works and values correct", {
                   dplyr::select(geo_value, time_value, cases))
 
 
-  expect_warning(p <- predict(wf, latest)) # Consider to change to expect_silent() after Issue 212 is fixed
+  p <- predict(wf, latest) # Consider to change to expect_silent() after Issue 212 is fixed
   expect_equal(nrow(p), 2L)
   expect_equal(ncol(p), 4L)
   expect_equal(p$.pred_scaled, p$.pred * c(20000, 30000))
@@ -127,7 +127,7 @@ test_that("Postprocessing workflow works and values correct", {
   wf <- epi_workflow(r, parsnip::linear_reg()) %>%
     fit(jhu) %>%
     add_frosting(f)
-  expect_warning(p <- predict(wf, latest)) # Consider to change to expect_silent() after Issue 212 is fixed
+  expect_message(p <- predict(wf, latest)) # Consider to change to expect_silent() after Issue 212 is fixed
   expect_equal(nrow(p), 2L)
   expect_equal(ncol(p), 4L)
   expect_equal(p$.pred_scaled, p$.pred * c(2, 3))

--- a/tests/testthat/test-population_scaling.R
+++ b/tests/testthat/test-population_scaling.R
@@ -87,7 +87,7 @@ test_that("Postprocessing workflow works and values correct", {
                             df_pop_col = "value",
                             by = c("geo_value" = "states"),
                             suffix = "_scaled") %>%
-    step_epi_lag(cases_scaled, lag = c(7, 14)) %>%
+    step_epi_lag(cases_scaled, lag = c(0, 7, 14)) %>%
     step_epi_ahead(cases_scaled, ahead = 7, role = "outcome") %>%
     step_naomit(all_predictors()) %>%
     step_naomit(all_outcomes(), skip = TRUE)
@@ -112,7 +112,7 @@ test_that("Postprocessing workflow works and values correct", {
                   dplyr::select(geo_value, time_value, cases))
 
 
-  expect_silent(p <- predict(wf, latest))
+  expect_warning(p <- predict(wf, latest)) # Consider to change to expect_silent() after Issue 212 is fixed
   expect_equal(nrow(p), 2L)
   expect_equal(ncol(p), 4L)
   expect_equal(p$.pred_scaled, p$.pred * c(20000, 30000))
@@ -127,7 +127,7 @@ test_that("Postprocessing workflow works and values correct", {
   wf <- epi_workflow(r, parsnip::linear_reg()) %>%
     fit(jhu) %>%
     add_frosting(f)
-  expect_silent(p <- predict(wf, latest))
+  expect_warning(p <- predict(wf, latest)) # Consider to change to expect_silent() after Issue 212 is fixed
   expect_equal(nrow(p), 2L)
   expect_equal(ncol(p), 4L)
   expect_equal(p$.pred_scaled, p$.pred * c(2, 3))
@@ -147,7 +147,7 @@ test_that("Postprocessing to get cases from case rate", {
                             df_pop_col = "value",
                             by = c("geo_value" = "states"),
                             case_rate, suffix = "_scaled") %>%
-    step_epi_lag(case_rate_scaled, lag = c(7, 14)) %>% # cases
+    step_epi_lag(case_rate_scaled, lag = c(0, 7, 14)) %>% # cases
     step_epi_ahead(case_rate_scaled, ahead = 7, role = "outcome") %>% # cases
     step_naomit(all_predictors()) %>%
     step_naomit(all_outcomes(), skip = TRUE)
@@ -171,7 +171,7 @@ test_that("Postprocessing to get cases from case rate", {
                             dplyr::select(geo_value, time_value, case_rate))
 
 
-  expect_silent(p <- predict(wf, latest))
+  expect_warning(p <- predict(wf, latest)) # Conside to change to expect_silent() after Issue 212 is fixed
   expect_equal(nrow(p), 2L)
   expect_equal(ncol(p), 4L)
   expect_equal(p$.pred_scaled, p$.pred * c(1/20000, 1/30000))
@@ -192,7 +192,7 @@ test_that("test joining by default columns", {
                             df_pop_col = "values",
                             by = NULL,
                             suffix = "_scaled") %>%
-    step_epi_lag(case_rate_scaled, lag = c(7, 14)) %>% # cases
+    step_epi_lag(case_rate_scaled, lag = c(0, 7, 14)) %>% # cases
     step_epi_ahead(case_rate_scaled, ahead = 7, role = "outcome") %>% # cases
     step_naomit(all_predictors()) %>%
     step_naomit(all_outcomes(), skip = TRUE)
@@ -221,7 +221,7 @@ test_that("test joining by default columns", {
                             dplyr::select(geo_value, time_value, case_rate))
 
 
-  expect_message(p <- predict(wf, latest))
+  expect_warning(p <- predict(wf, latest)) # Consider to change to expect_message() after Issue 212 is fixed
 
 })
 
@@ -241,7 +241,7 @@ test_that("expect error if `by` selector does not match", {
                             df_pop_col = "values",
                             by = c("a" = "b"),
                             suffix = "_scaled") %>%
-    step_epi_lag(case_rate_scaled, lag = c(7, 14)) %>% # cases
+    step_epi_lag(case_rate_scaled, lag = c(0, 7, 14)) %>% # cases
     step_epi_ahead(case_rate_scaled, ahead = 7, role = "outcome") %>% # cases
     step_naomit(all_predictors()) %>%
     step_naomit(all_outcomes(), skip = TRUE)
@@ -265,7 +265,7 @@ test_that("expect error if `by` selector does not match", {
                             df_pop_col = "values",
                             by = c("geo_value" = "geo_value"),
                             suffix = "_scaled") %>%
-    step_epi_lag(case_rate_scaled, lag = c(7, 14)) %>% # cases
+    step_epi_lag(case_rate_scaled, lag = c(0, 7, 14)) %>% # cases
     step_epi_ahead(case_rate_scaled, ahead = 7, role = "outcome") %>% # cases
     step_naomit(all_predictors()) %>%
     step_naomit(all_outcomes(), skip = TRUE)
@@ -289,7 +289,7 @@ test_that("expect error if `by` selector does not match", {
     fit(jhu) %>%
     add_frosting(f)
 
-  expect_error(predict(wf, latest))
+  expect_error(suppressWarnings(predict(wf, latest))) # Consider to take out suppressWarnings() after fix Issue 212
 })
 
 
@@ -325,7 +325,7 @@ test_that("Rate rescaling behaves as expected", {
     as_epi_df()
 
   r <- epi_recipe(x) %>%
-    step_epi_lag(case_rate, lag = c(7, 14)) %>% # cases
+    step_epi_lag(case_rate, lag = c(0, 7, 14)) %>% # cases
     step_epi_ahead(case_rate, ahead = 7, role = "outcome") %>% # cases
     step_naomit(all_predictors()) %>%
     step_naomit(all_outcomes(), skip = TRUE)

--- a/tests/testthat/test-population_scaling.R
+++ b/tests/testthat/test-population_scaling.R
@@ -112,7 +112,7 @@ test_that("Postprocessing workflow works and values correct", {
                   dplyr::select(geo_value, time_value, cases))
 
 
-  expect_silent(p <- predict(wf, latest)) # Consider to change to expect_silent() after Issue 212 is fixed
+  expect_silent(p <- predict(wf, latest))
   expect_equal(nrow(p), 2L)
   expect_equal(ncol(p), 4L)
   expect_equal(p$.pred_scaled, p$.pred * c(20000, 30000))
@@ -127,7 +127,7 @@ test_that("Postprocessing workflow works and values correct", {
   wf <- epi_workflow(r, parsnip::linear_reg()) %>%
     fit(jhu) %>%
     add_frosting(f)
-  expect_silent(p <- predict(wf, latest)) # Consider to change to expect_silent() after Issue 212 is fixed
+  expect_silent(p <- predict(wf, latest))
   expect_equal(nrow(p), 2L)
   expect_equal(ncol(p), 4L)
   expect_equal(p$.pred_scaled, p$.pred * c(2, 3))
@@ -171,7 +171,7 @@ test_that("Postprocessing to get cases from case rate", {
                             dplyr::select(geo_value, time_value, case_rate))
 
 
-  expect_silent(p <- predict(wf, latest)) # Conside to change to expect_silent() after Issue 212 is fixed
+  expect_silent(p <- predict(wf, latest))
   expect_equal(nrow(p), 2L)
   expect_equal(ncol(p), 4L)
   expect_equal(p$.pred_scaled, p$.pred * c(1/20000, 1/30000))
@@ -221,7 +221,7 @@ test_that("test joining by default columns", {
                             dplyr::select(geo_value, time_value, case_rate))
 
 
-  expect_message(p <- predict(wf, latest)) # Consider to change to expect_message() after Issue 212 is fixed
+  expect_message(p <- predict(wf, latest))
 
 })
 
@@ -289,7 +289,7 @@ test_that("expect error if `by` selector does not match", {
     fit(jhu) %>%
     add_frosting(f)
 
-  expect_error(suppressWarnings(predict(wf, latest))) # Consider to take out suppressWarnings() after fix Issue 212
+  expect_error(predict(wf, latest))
 })
 
 

--- a/tests/testthat/test-population_scaling.R
+++ b/tests/testthat/test-population_scaling.R
@@ -112,7 +112,7 @@ test_that("Postprocessing workflow works and values correct", {
                   dplyr::select(geo_value, time_value, cases))
 
 
-  p <- predict(wf, latest) # Consider to change to expect_silent() after Issue 212 is fixed
+  expect_silent(p <- predict(wf, latest)) # Consider to change to expect_silent() after Issue 212 is fixed
   expect_equal(nrow(p), 2L)
   expect_equal(ncol(p), 4L)
   expect_equal(p$.pred_scaled, p$.pred * c(20000, 30000))
@@ -127,7 +127,7 @@ test_that("Postprocessing workflow works and values correct", {
   wf <- epi_workflow(r, parsnip::linear_reg()) %>%
     fit(jhu) %>%
     add_frosting(f)
-  expect_message(p <- predict(wf, latest)) # Consider to change to expect_silent() after Issue 212 is fixed
+  expect_silent(p <- predict(wf, latest)) # Consider to change to expect_silent() after Issue 212 is fixed
   expect_equal(nrow(p), 2L)
   expect_equal(ncol(p), 4L)
   expect_equal(p$.pred_scaled, p$.pred * c(2, 3))
@@ -171,7 +171,7 @@ test_that("Postprocessing to get cases from case rate", {
                             dplyr::select(geo_value, time_value, case_rate))
 
 
-  expect_warning(p <- predict(wf, latest)) # Conside to change to expect_silent() after Issue 212 is fixed
+  expect_silent(p <- predict(wf, latest)) # Conside to change to expect_silent() after Issue 212 is fixed
   expect_equal(nrow(p), 2L)
   expect_equal(ncol(p), 4L)
   expect_equal(p$.pred_scaled, p$.pred * c(1/20000, 1/30000))
@@ -221,7 +221,7 @@ test_that("test joining by default columns", {
                             dplyr::select(geo_value, time_value, case_rate))
 
 
-  expect_warning(p <- predict(wf, latest)) # Consider to change to expect_message() after Issue 212 is fixed
+  expect_message(p <- predict(wf, latest)) # Consider to change to expect_message() after Issue 212 is fixed
 
 })
 


### PR DESCRIPTION
Addresses Issue #199 (modified `get_test_data()` function + added a test). Basically, omitted the end rows according to the min # of lags in the recipe when that's not 0.