### PR TITLE
Possible fix so that people may be able to use lower versions of R

### DIFF
--- a/R/make_quantile_reg.R
+++ b/R/make_quantile_reg.R
@@ -102,9 +102,9 @@ make_quantile_reg <- function() {
     # can't make a method because object is second
     out <- switch(
       type,
-      rq = dist_quantiles(x, object$tau), # one quantile
+      rq = dist_quantiles(unname(as.list(x)), object$tau), # one quantile
       rqs = {
-        x <- unname(apply(x, 1, function(q) unname(sort(q)), simplify = FALSE))
+        x <- unname(as.list(as.data.frame(apply(x, 1, function(q) unname(sort(q))))))
         dist_quantiles(x, list(object$tau))
       },
       rlang::abort(c("Prediction not implemented for this `rq` type.",

--- a/R/make_quantile_reg.R
+++ b/R/make_quantile_reg.R
@@ -104,7 +104,7 @@ make_quantile_reg <- function() {
       type,
       rq = dist_quantiles(unname(as.list(x)), object$tau), # one quantile
       rqs = {
-        x <- unname(as.list(as.data.frame(apply(x, 1, function(q) unname(sort(q))))))
+        x <- lapply(unname(split(x, seq(nrow(x)))), function(q) sort(q))
         dist_quantiles(x, list(object$tau))
       },
       rlang::abort(c("Prediction not implemented for this `rq` type.",


### PR DESCRIPTION
Addresses #213 so that users may be able to use the epipredict package in lower versions of R. To do this, in `make_quantile_reg()` removed `simplify = FALSE` and wrapped apply in  `unname(as.list(as.data.frame()))`, so that we get a list that looks to be compatible with `dist_quantiles()` - similar in format to the documentation example given there.
