### PR TITLE
172 arx lags list

### DIFF
--- a/R/canned-epipred.R
+++ b/R/canned-epipred.R
@@ -22,6 +22,7 @@ validate_forecaster_inputs <- function(epi_data, outcome, predictors) {
 
 arx_lags_validator <- function(predictors, lags) {
   p <- length(predictors)
+
   if (!is.list(lags)) lags <- list(lags)
   l <- length(lags)
   if (l == 1) lags <- rep(lags, p)
@@ -30,6 +31,21 @@ arx_lags_validator <- function(predictors, lags) {
       "You have requested {p} predictor(s) but {l} different lags.",
       i = "Lags must be a vector or a list with length == number of predictors."
     ))
+  }else{
+    if(length(lags) == sum(names(lags) != "", na.rm = TRUE)){
+      if(!all(names(lags) %in% predictors)){
+        cli::cli_abort(
+          "The names for the list of lags do not all correspond to the predictors."
+        )
+      } else{
+        lags <- lags[order(match(names(lags), predictors))]
+      }
+    } else{
+      cli::cli_warn(
+        "The unnamed list of lags has been set to correspond to the order
+          of the predictors.",
+      )
+    }
   }
   lags
 }

--- a/tests/testthat/test-arx_args_list.R
+++ b/tests/testthat/test-arx_args_list.R
@@ -52,5 +52,55 @@ test_that("arx forecaster disambiguates quantiles", {
   expect_error(compare_quantile_args(alist, tlist))
 })
 
+test_that("arx_lags_validator handles named & unnamed lists as expected", {
 
+  # Fully named list of lags in order of predictors
+  pred_vec <- c("death_rate", "case_rate")
+  lags_init_fn <- list(death_rate = c(0, 7, 14), case_rate = c(0, 1, 2, 3, 7, 14))
+
+  expect_equal(epipredict:::arx_lags_validator(pred_vec, lags_init_fn),
+               lags_init_fn)
+
+  # Fully named list of lags not in order of predictors
+  lags_finit_fn_switch <- list(case_rate = c(0, 1, 2, 3, 7, 14), death_rate = c(0, 7, 14))
+
+  expect_equal(epipredict:::arx_lags_validator(pred_vec, lags_finit_fn_switch),
+               list(death_rate = c(0, 7, 14), case_rate = c(0, 1, 2, 3, 7, 14)))
+
+  # Fully named list of lags not in order of predictors (longer ex.)
+  pred_vec2 <-  c("death_rate", "other_var", "case_rate")
+  lags_finit_fn_switch2 <- list(case_rate = c(0, 1, 2, 3, 7, 14), death_rate = c(0, 7, 14),
+                               other_var = c(0, 1))
+  expect_equal(epipredict:::arx_lags_validator(pred_vec2, lags_finit_fn_switch2),
+               list(death_rate = c(0, 7, 14),
+                    other_var = c(0, 1), case_rate = c(0, 1, 2, 3, 7, 14)))
+
+  # More lags than predictors - Error
+  expect_error(epipredict:::arx_lags_validator(pred_vec, lags_finit_fn_switch2))
+
+  # Unnamed list of lags - Warning
+  lags_init_un <- list(c(0, 7, 14), c(0, 1, 2, 3, 7, 14))
+
+  expect_warning(lags_aft_un <- epipredict:::arx_lags_validator(pred_vec, lags_init_un))
+  expect_equal(lags_aft_un, lags_init_un)
+
+  # Partially named list of lags - treat as unnamed - Warning
+  lags_init_pn <- list(death_rate = c(0, 7, 14), c(0, 1, 2, 3, 7, 14))
+
+  expect_warning(lags_aft_pn <- epipredict:::arx_lags_validator(pred_vec, lags_init_pn))
+  expect_equal(lags_aft_pn, lags_init_pn)
+
+  # NA name - treat as unnamed list - Warning
+  lags_init_na <- list(c(0, 7, 14), c(0, 1, 2, 3, 7, 14))
+  names(lags_init_na) <- "death_rate"
+
+  expect_warning(lags_aft_na <- epipredict:::arx_lags_validator(pred_vec, lags_init_na))
+  expect_equal(lags_aft_na, lags_init_na)
+
+  # Try use a name not in predictors - Error
+  lags_init_other_name <- list(death_rate = c(0, 7, 14), test_var = c(0, 1, 2, 3, 7, 14))
+
+  expect_error(epipredict:::arx_lags_validator(pred_vec, lags_init_other_name))
+
+})
 


### PR DESCRIPTION
Closes Issue #172: Check if the lags list is named. If so, validate and order correctly. If not, assume it's the same as the order of the predictors. Added the relevant code to `arx_lags_validator()` as that seemed to be a good place to have it. Also, added some tests to test-arx_args_list.R.

A couple questions/things to consider…
- I think we should shoot out a warning if we’re assuming that an unnamed list of lags is in the same order as the predictors (I’ve added this).
- I was thinking about partially named lists (ex. name one element but not the others)… If we really want, we can try to handle those (though I think that may become complicated - such as if someone specifies just a few names in a long list). For now, I’ve just treated that as incomplete and, hence, as an unnamed list.
