### PR TITLE
fix: #222 don't add extra columns in `step_population_scaling` or `layer_population_scaling`

### DIFF
--- a/R/layer_population_scaling.R
+++ b/R/layer_population_scaling.R
@@ -147,6 +147,7 @@ slather.layer_population_scaling <-
     pos <- tidyselect::eval_select(exprs, components$predictions)
     col_names <- names(pos)
     suffix = ifelse(object$create_new, object$suffix, "")
+    col_to_remove <- setdiff(colnames(object$df), colnames(components$predictions))
 
     components$predictions <- dplyr::left_join(
       components$predictions,
@@ -156,9 +157,10 @@ slather.layer_population_scaling <-
     ) %>%
       dplyr::mutate(dplyr::across(
         dplyr::all_of(col_names),
-        ~.x * !!pop_col / object$rate_rescaling ,
-        .names = "{.col}{suffix}")) %>%
-     dplyr::select(-!!pop_col)
+        ~ .x * !!pop_col / object$rate_rescaling,
+        .names = "{.col}{suffix}"
+      )) %>%
+      dplyr::select(-any_of(col_to_remove))
     components
   }
 

--- a/R/layer_population_scaling.R
+++ b/R/layer_population_scaling.R
@@ -160,7 +160,7 @@ slather.layer_population_scaling <-
         ~ .x * !!pop_col / object$rate_rescaling,
         .names = "{.col}{suffix}"
       )) %>%
-      dplyr::select(-any_of(col_to_remove))
+      dplyr::select(-dplyr::any_of(col_to_remove))
     components
   }
 

--- a/R/step_population_scaling.R
+++ b/R/step_population_scaling.R
@@ -203,6 +203,7 @@ bake.step_population_scaling <- function(object,
 
   pop_col = rlang::sym(object$df_pop_col)
   suffix = ifelse(object$create_new, object$suffix, "")
+  col_to_remove <- setdiff(colnames(object$df), colnames(new_data))
 
   dplyr::left_join(new_data,
                    object$df,
@@ -211,8 +212,7 @@ bake.step_population_scaling <- function(object,
         ~.x * object$rate_rescaling /!!pop_col ,
         .names = "{.col}{suffix}")) %>%
     # removed so the models do not use the population column
-   dplyr::select(-!!pop_col)
-
+    dplyr::select(-any_of(col_to_remove))
 }
 
 #' @export

--- a/R/step_population_scaling.R
+++ b/R/step_population_scaling.R
@@ -212,7 +212,7 @@ bake.step_population_scaling <- function(object,
         ~.x * object$rate_rescaling /!!pop_col ,
         .names = "{.col}{suffix}")) %>%
     # removed so the models do not use the population column
-    dplyr::select(-any_of(col_to_remove))
+    dplyr::select(-dplyr::any_of(col_to_remove))
 }
 
 #' @export

--- a/R/utils-arg.R
+++ b/R/utils-arg.R
@@ -179,7 +179,7 @@ arg_is_sorted = function(..., allow_null = FALSE) {
 arg_to_date <- function(x, allow_null = FALSE, allow_na = FALSE) {
   arg_is_scalar(x, allow_null = allow_null, allow_na = allow_na)
   if (!is.null(x)) {
-    x <- tryCatch(as.Date(x), error = function(e) NA)
+    x <- tryCatch(as.Date(x, origin = "1970-01-01"), error = function(e) NA)
   }
   arg_is_date(x, allow_null = allow_null, allow_na = allow_na)
   x

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -6,7 +6,10 @@
 
 .onLoad <- function(libname, pkgname) {
   make_flatline_reg()
-  make_quantile_reg()
-  make_smooth_quantile_reg()
+  if (!exists("quantile_reg")) {
+    make_quantile_reg()
+  }
+  if (!exists("smooth_quantile_reg")) {
+    make_smooth_quantile_reg()
+  }
 }
-

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -6,10 +6,6 @@
 
 .onLoad <- function(libname, pkgname) {
   make_flatline_reg()
-  if (!exists("quantile_reg")) {
-    make_quantile_reg()
-  }
-  if (!exists("smooth_quantile_reg")) {
-    make_smooth_quantile_reg()
-  }
+  make_quantile_reg()
+  make_smooth_quantile_reg()
 }

--- a/tests/testthat/test-population_scaling.R
+++ b/tests/testthat/test-population_scaling.R
@@ -350,4 +350,50 @@ test_that("Rate rescaling behaves as expected", {
                unique(predict(wf, latest)$.pred_scaled)))
 })
 
+test_that("Extra Columns are ignored", {
+  x <- tibble(
+    geo_value = rep("place", 50),
+    time_value = as.Date("2021-01-01") + 0:49,
+    case_rate = rep(0.0005, 50),
+    cases = rep(5000, 50)
+  ) %>%
+    as_epi_df()
 
+  reverse_pop_data <- data.frame(
+    states = c("place"),
+    value = c(1 / 1000),
+    extra_col = c("full name")
+  )
+  recip <- epi_recipe(x) %>%
+    step_population_scaling(
+      df = reverse_pop_data,
+      df_pop_col = "value",
+      rate_rescaling = 100, # cases per 100
+      by = c("geo_value" = "states"),
+      case_rate, suffix = "_scaled"
+    ) %>%
+    step_epi_lag(case_rate_scaled, lag = c(0, 7, 14)) %>% # cases
+    step_epi_ahead(case_rate, ahead = 7, role = "outcome") %>% # cases
+    step_naomit(all_predictors()) %>%
+    step_naomit(all_outcomes(), skip = TRUE)
+  expect_equal(ncol(bake(prep(recip, x), x)), 8)
+  # done testing step_*
+
+  frost <- frosting() %>%
+    layer_predict() %>%
+    layer_threshold(.pred) %>%
+    layer_naomit(.pred) %>%
+    layer_population_scaling(.pred,
+      df = reverse_pop_data,
+      rate_rescaling = 100, # revert back to case rate per 100
+      by = c("geo_value" = "states"),
+      df_pop_col = "value"
+    )
+
+  wf <- epi_workflow(recip, parsnip::linear_reg()) %>%
+    fit(x) %>%
+    add_frosting(frost)
+  latest <- get_test_data(recipe = recip, x = x)
+  # suppress warning: prediction from a rank-deficient fit may be misleading
+  suppressWarnings(expect_equal(ncol(predict(wf, latest)), 4))
+})

--- a/tests/testthat/test-population_scaling.R
+++ b/tests/testthat/test-population_scaling.R
@@ -376,7 +376,7 @@ test_that("Extra Columns are ignored", {
     step_epi_ahead(case_rate, ahead = 7, role = "outcome") %>% # cases
     step_naomit(all_predictors()) %>%
     step_naomit(all_outcomes(), skip = TRUE)
-  expect_equal(ncol(bake(prep(recip, x), x)), 8)
+  expect_equal(ncol(bake(prep(recip, x), x)), 9)
   # done testing step_*
 
   frost <- frosting() %>%


### PR DESCRIPTION
fixes #222. Hopefully the tests are fairly self explanatory. All this had to do was remove any column in the auxillary `df` and not in the main data frame, instead of _just_ the population column.