### PR TITLE
Set R-CMD-check to run on push & PR to v0.0.6

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,9 +4,9 @@
 # Created with usethis + edited to use API key.
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, v0.0.6]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, v0.0.6]
 
 name: R-CMD-check
 


### PR DESCRIPTION
Using the quick fix suggested by @dsweber2.

This only enables the checks on pushes & PRs to v0.0.6.  If PRs to v0.0.6 are merged, this will NOT update the pkgdown site.  @dajmcdon Would we be merging to v0.0.6 & want the pkgdown site to be updated?