### PR TITLE
CI: add CI button

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,6 +3,7 @@
 #
 # Created with usethis + edited to use API key.
 on:
+  workflow_dispatch:
   push:
     branches: [main, master, v0.0.6]
   pull_request:


### PR DESCRIPTION
Not sure why adding a commit on #243 didn't trigger the action; this is adding a button to do it manually when you want