### PR TITLE
Add documentation for `arx_forecaster` and `sliding`

### DIFF
--- a/R/arx_forecaster.R
+++ b/R/arx_forecaster.R
@@ -2,7 +2,10 @@
 #'
 #' This is an autoregressive forecasting model for
 #' [epiprocess::epi_df] data. It does "direct" forecasting, meaning
-#' that it estimates a model for a particular target horizon.
+#' that it estimates a model for a particular target horizon. The
+#' forecaster trains one model using data over all available
+#' geo_value, and produces forecasts for `target_date = max(epi_df$time_value)
+#' + arx_arg_list()$ahead`.  
 #'
 #'
 #' @param epi_data An `epi_df` object

--- a/vignettes/articles/sliding.Rmd
+++ b/vignettes/articles/sliding.Rmd
@@ -309,6 +309,11 @@ k_week_version_aware <- function(ahead = 7, version_aware = TRUE) {
         args_list = arx_args_list(ahead = ahead)
       ) %>%
         extract2("predictions"),
+      # Both `before` in `epi_slide` and `n_training` in `arx_forecaster()`
+      # Controls number of traning samples forecaster can see
+      # `before` first controls the number of samples at a particular step 
+      # of `epi_slide`, then `n_training` further restricts max training sample
+      # in that partiuclar step `arx_forecaster()` could use.
       before = 120 - 1,
       ref_time_values = fc_time_values,
       new_col_name = "fc"


### PR DESCRIPTION
Added `arx_forecaster` only produces predictions for the largest time_value + ahead; and trains one model over all geo_value.

Specified how `before` and `n_traning`
controls number of training samples in `sliding`