### PR TITLE
feat: canned forecasters print their args by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.0.x will indicat
 
 # epipredict 0.1
 
+- canned forecaster workflow functions (such as `arx_forecaster()`) now display their parameters by default; this can be turned off with `.verbose = FALSE`
 - `*_args_list()` functions now warn if `forecast_date + ahead != target_date`
 - `layer_residual_quantiles()` will now error if any of the residual quantiles are NA
 - add `check_enough_train_data` that will error if training data is too small

--- a/R/arx_classifier.R
+++ b/R/arx_classifier.R
@@ -18,6 +18,7 @@
 #'   also be used.
 #' @param args_list A list of customization arguments to determine
 #'   the type of forecasting model. See [arx_class_args_list()].
+#' @param .verbose If true, prints the arguments used in the workflow.
 #'
 #' @return A list with (1) `predictions` an `epi_df` of predicted classes
 #'   and (2) `epi_workflow`, a list that encapsulates the entire estimation
@@ -46,13 +47,14 @@ arx_classifier <- function(
     outcome,
     predictors,
     trainer = parsnip::logistic_reg(),
-    args_list = arx_class_args_list()) {
+    args_list = arx_class_args_list(),
+    .verbose = TRUE) {
   if (!is_classification(trainer)) {
     cli::cli_abort("`trainer` must be a {.pkg parsnip} model of mode 'classification'.")
   }
 
   wf <- arx_class_epi_workflow(
-    epi_data, outcome, predictors, trainer, args_list
+    epi_data, outcome, predictors, trainer, args_list, .verbose
   )
 
   latest <- get_test_data(
@@ -118,7 +120,8 @@ arx_class_epi_workflow <- function(
     outcome,
     predictors,
     trainer = NULL,
-    args_list = arx_class_args_list()) {
+    args_list = arx_class_args_list(),
+    .verbose = TRUE) {
   validate_forecaster_inputs(epi_data, outcome, predictors)
   if (!inherits(args_list, c("arx_class", "alist"))) {
     rlang::abort("args_list was not created using `arx_class_args_list().")
@@ -127,6 +130,11 @@ arx_class_epi_workflow <- function(
     rlang::abort("`trainer` must be a `{parsnip}` model of mode 'classification'.")
   }
   lags <- arx_lags_validator(predictors, args_list$lags)
+
+  if (.verbose) {
+    cli::cli_inform("Creating ARX Classifier Workflow with the following arguments:")
+    print(args_list)
+  }
 
   # --- preprocessor
   # ------- predictors

--- a/R/cdc_baseline_forecaster.R
+++ b/R/cdc_baseline_forecaster.R
@@ -16,6 +16,7 @@
 #' @param outcome A scalar character for the column name we wish to predict.
 #' @param args_list A list of additional arguments as created by the
 #'   [cdc_baseline_args_list()] constructor function.
+#' @param .verbose If true, prints the arguments used in the workflow.
 #'
 #' @return A data frame of point and interval forecasts for all aheads (unique
 #'   horizons) for each unique combination of `key_vars`.
@@ -58,7 +59,8 @@
 cdc_baseline_forecaster <- function(
     epi_data,
     outcome,
-    args_list = cdc_baseline_args_list()) {
+    args_list = cdc_baseline_args_list(),
+    .verbose = TRUE) {
   validate_forecaster_inputs(epi_data, outcome, "time_value")
   if (!inherits(args_list, c("cdc_flat_fcast", "alist"))) {
     cli_stop("args_list was not created using `cdc_baseline_args_list().")
@@ -67,6 +69,10 @@ cdc_baseline_forecaster <- function(
   ek <- kill_time_value(keys)
   outcome <- rlang::sym(outcome)
 
+  if (.verbose) {
+    cli::cli_inform("Creating CDC Baseline Forecaster Workflow with the following arguments:")
+    print(args_list)
+  }
 
   r <- epi_recipe(epi_data) %>%
     step_epi_ahead(!!outcome, ahead = args_list$data_frequency, skip = TRUE) %>%

--- a/R/flatline_forecaster.R
+++ b/R/flatline_forecaster.R
@@ -17,6 +17,7 @@
 #' @param outcome A scalar character for the column name we wish to predict.
 #' @param args_list A list of dditional arguments as created by the
 #'   [flatline_args_list()] constructor function.
+#' @param .verbose If true, prints the arguments used in the workflow.
 #'
 #' @return A data frame of point (and optionally interval) forecasts at a single
 #'   ahead (unique horizon) for each unique combination of `key_vars`.
@@ -30,7 +31,8 @@
 flatline_forecaster <- function(
     epi_data,
     outcome,
-    args_list = flatline_args_list()) {
+    args_list = flatline_args_list(),
+    .verbose = TRUE) {
   validate_forecaster_inputs(epi_data, outcome, "time_value")
   if (!inherits(args_list, c("flat_fcast", "alist"))) {
     cli_stop("args_list was not created using `flatline_args_list().")
@@ -39,6 +41,10 @@ flatline_forecaster <- function(
   ek <- kill_time_value(keys)
   outcome <- rlang::sym(outcome)
 
+  if (.verbose) {
+    cli::cli_inform("Creating Flatline Forecaster Workflow with the following arguments:")
+    print(args_list)
+  }
 
   r <- epi_recipe(epi_data) %>%
     step_epi_ahead(!!outcome, ahead = args_list$ahead, skip = TRUE) %>%

--- a/man/arx_class_epi_workflow.Rd
+++ b/man/arx_class_epi_workflow.Rd
@@ -9,7 +9,8 @@ arx_class_epi_workflow(
   outcome,
   predictors,
   trainer = NULL,
-  args_list = arx_class_args_list()
+  args_list = arx_class_args_list(),
+  .verbose = TRUE
 )
 }
 \arguments{
@@ -33,6 +34,8 @@ also be used. May be \code{NULL} (the default).}
 
 \item{args_list}{A list of customization arguments to determine
 the type of forecasting model. See \code{\link[=arx_class_args_list]{arx_class_args_list()}}.}
+
+\item{.verbose}{If true, prints the arguments used in the workflow.}
 }
 \value{
 An unfit \code{epi_workflow}.

--- a/man/arx_classifier.Rd
+++ b/man/arx_classifier.Rd
@@ -9,7 +9,8 @@ arx_classifier(
   outcome,
   predictors,
   trainer = parsnip::logistic_reg(),
-  args_list = arx_class_args_list()
+  args_list = arx_class_args_list(),
+  .verbose = TRUE
 )
 }
 \arguments{
@@ -33,6 +34,8 @@ also be used.}
 
 \item{args_list}{A list of customization arguments to determine
 the type of forecasting model. See \code{\link[=arx_class_args_list]{arx_class_args_list()}}.}
+
+\item{.verbose}{If true, prints the arguments used in the workflow.}
 }
 \value{
 A list with (1) \code{predictions} an \code{epi_df} of predicted classes

--- a/man/arx_fcast_epi_workflow.Rd
+++ b/man/arx_fcast_epi_workflow.Rd
@@ -9,7 +9,8 @@ arx_fcast_epi_workflow(
   outcome,
   predictors,
   trainer = NULL,
-  args_list = arx_args_list()
+  args_list = arx_args_list(),
+  .verbose = TRUE
 )
 }
 \arguments{
@@ -26,6 +27,8 @@ For now, we enforce \code{mode = "regression"}. May be \code{NULL} (the default)
 
 \item{args_list}{A list of customization arguments to determine
 the type of forecasting model. See \code{\link[=arx_args_list]{arx_args_list()}}.}
+
+\item{.verbose}{If true, prints the arguments used in the workflow.}
 }
 \value{
 An unfitted \code{epi_workflow}.

--- a/man/arx_forecaster.Rd
+++ b/man/arx_forecaster.Rd
@@ -9,7 +9,8 @@ arx_forecaster(
   outcome,
   predictors,
   trainer = parsnip::linear_reg(),
-  args_list = arx_args_list()
+  args_list = arx_args_list(),
+  .verbose = TRUE
 )
 }
 \arguments{
@@ -26,6 +27,8 @@ For now, we enforce \code{mode = "regression"}.}
 
 \item{args_list}{A list of customization arguments to determine
 the type of forecasting model. See \code{\link[=arx_args_list]{arx_args_list()}}.}
+
+\item{.verbose}{If true, prints the arguments used in the workflow.}
 }
 \value{
 A list with (1) \code{predictions} an \code{epi_df} of predicted values

--- a/man/cdc_baseline_forecaster.Rd
+++ b/man/cdc_baseline_forecaster.Rd
@@ -7,7 +7,8 @@
 cdc_baseline_forecaster(
   epi_data,
   outcome,
-  args_list = cdc_baseline_args_list()
+  args_list = cdc_baseline_args_list(),
+  .verbose = TRUE
 )
 }
 \arguments{
@@ -17,6 +18,8 @@ cdc_baseline_forecaster(
 
 \item{args_list}{A list of additional arguments as created by the
 \code{\link[=cdc_baseline_args_list]{cdc_baseline_args_list()}} constructor function.}
+
+\item{.verbose}{If true, prints the arguments used in the workflow.}
 }
 \value{
 A data frame of point and interval forecasts for all aheads (unique

--- a/man/flatline_forecaster.Rd
+++ b/man/flatline_forecaster.Rd
@@ -4,7 +4,12 @@
 \alias{flatline_forecaster}
 \title{Predict the future with today's value}
 \usage{
-flatline_forecaster(epi_data, outcome, args_list = flatline_args_list())
+flatline_forecaster(
+  epi_data,
+  outcome,
+  args_list = flatline_args_list(),
+  .verbose = TRUE
+)
 }
 \arguments{
 \item{epi_data}{An \link[epiprocess:epi_df]{epiprocess::epi_df}}
@@ -13,6 +18,8 @@ flatline_forecaster(epi_data, outcome, args_list = flatline_args_list())
 
 \item{args_list}{A list of dditional arguments as created by the
 \code{\link[=flatline_args_list]{flatline_args_list()}} constructor function.}
+
+\item{.verbose}{If true, prints the arguments used in the workflow.}
 }
 \value{
 A data frame of point (and optionally interval) forecasts at a single

--- a/tests/testthat/test-layer_residual_quantiles.R
+++ b/tests/testthat/test-layer_residual_quantiles.R
@@ -79,22 +79,24 @@ test_that("Canned forecasters work with / without", {
   attr(jhu, "metadata") <- meta
 
   expect_silent(
-    flatline_forecaster(jhu, "death_rate")
+    flatline_forecaster(jhu, "death_rate", .verbose = FALSE)
   )
   expect_silent(
     flatline_forecaster(
       jhu, "death_rate",
-      args_list = flatline_args_list(quantile_by_key = "geo_value")
+      args_list = flatline_args_list(quantile_by_key = "geo_value"),
+      .verbose = FALSE
     )
   )
 
   expect_silent(
-    arx_forecaster(jhu, "death_rate", c("case_rate", "death_rate"))
+    arx_forecaster(jhu, "death_rate", c("case_rate", "death_rate"), .verbose = FALSE)
   )
   expect_silent(
     flatline_forecaster(
       jhu, "death_rate",
-      args_list = flatline_args_list(quantile_by_key = "geo_value")
+      args_list = flatline_args_list(quantile_by_key = "geo_value"),
+      .verbose = FALSE
     )
   )
 })


### PR DESCRIPTION
### Checklist

Please:

-   [x] Make sure this PR is against "dev", not "main".
-   [x] Request a review from one of the current epipredict main reviewers:
        dajmcdon.
-   [ ] ~~Makes sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
        Always increment the patch version number (the third number), unless you are
        making a release PR from dev to main, in which case increment the minor
        version number (the second number).~~
-   [x] Describe changes made in NEWS.md, making sure breaking changes
        (backwards-incompatible changes to the documented interface) are noted.
        Collect the changes under the next release number (e.g. if you are on
        0.7.2, then write your changes under the 0.8 heading).

### Change explanations for reviewer

Adds `.verbose = TRUE` to canned forecasters and prints their arguments if TRUE.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

-   Resolves #309
