### PR TITLE
refactor: consistent default for trainer arg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epipredict
 Title: Basic epidemiology forecasting methods
-Version: 0.0.12
+Version: 0.0.13
 Authors@R: c(
     person("Daniel", "McDonald", , "daniel@stat.ubc.ca", role = c("aut", "cre")),
     person("Ryan", "Tibshirani", , "ryantibs@cmu.edu", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,11 +4,6 @@ Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.0.x will indicat
 
 # epipredict 0.1
 
-- the `predictor` argument in `arx_forecaster()` now defaults to the value of the `outcome` argument
-- `*_args_list()` functions now warn if `forecast_date + ahead != target_date`
-- `layer_residual_quantiles()` will now error if any of the residual quantiles are NA
-- add `check_enough_train_data()` that will error if training data is too small
-- added `check_enough_train_data()` to `arx_forecaster()`
 - simplify `layer_residual_quantiles()` to avoid timesuck in `utils::methods()`
 - rename the `dist_quantiles()` to be more descriptive, breaking change
 - removes previous `pivot_quantiles()` (now `*_wider()`, breaking change)
@@ -38,3 +33,10 @@ Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.0.x will indicat
 - refactor quantile extrapolation (possibly creates different results)
 - force `target_date` + `forecast_date` handling to match the time_type of
   the epi_df. allows for annual and weekly data
+- add `check_enough_train_data()` that will error if training data is too small
+- added `check_enough_train_data()` to `arx_forecaster()`
+- `layer_residual_quantiles()` will now error if any of the residual quantiles are NA
+- `*_args_list()` functions now warn if `forecast_date + ahead != target_date`
+- the `predictor` argument in `arx_forecaster()` now defaults to the value of the `outcome` argument
+- `arx_fcast_epi_workflow()` and `arx_class_epi_workflow()` now default to
+  `trainer = parsnip::logistic_reg()` to match their more canned versions.

--- a/R/arx_classifier.R
+++ b/R/arx_classifier.R
@@ -87,11 +87,11 @@ arx_classifier <- function(
 #' may alter the returned `epi_workflow` object but can be omitted.
 #'
 #' @inheritParams arx_classifier
-#' @param trainer A `{parsnip}` model describing the type of estimation.
-#'  For now, we enforce `mode = "classification"`. Typical values are
+#' @param trainer A `{parsnip}` model describing the type of estimation. For
+#'  now, we enforce `mode = "classification"`. Typical values are
 #'  [parsnip::logistic_reg()] or [parsnip::multinom_reg()]. More complicated
-#'  trainers like [parsnip::naive_Bayes()] or [parsnip::rand_forest()] can
-#'  also be used. May be `NULL` (the default).
+#'  trainers like [parsnip::naive_Bayes()] or [parsnip::rand_forest()] can also
+#'  be used. May be `NULL` if you'd like to decide later.
 #'
 #' @return An unfit `epi_workflow`.
 #' @export
@@ -117,7 +117,7 @@ arx_class_epi_workflow <- function(
     epi_data,
     outcome,
     predictors,
-    trainer = NULL,
+    trainer = parsnip::logistic_reg(),
     args_list = arx_class_args_list()) {
   validate_forecaster_inputs(epi_data, outcome, predictors)
   if (!inherits(args_list, c("arx_class", "alist"))) {

--- a/R/arx_forecaster.R
+++ b/R/arx_forecaster.R
@@ -83,8 +83,9 @@ arx_forecaster <- function(epi_data,
 #' use [quantile_reg()]) but can be omitted.
 #'
 #' @inheritParams arx_forecaster
-#' @param trainer A `{parsnip}` model describing the type of estimation.
-#'   For now, we enforce `mode = "regression"`. May be `NULL` (the default).
+#' @param trainer A `{parsnip}` model describing the type of estimation. For
+#'   now, we enforce `mode = "regression"`. May be `NULL` if you'd like to
+#'   decide later.
 #'
 #' @return An unfitted `epi_workflow`.
 #' @export
@@ -108,7 +109,7 @@ arx_fcast_epi_workflow <- function(
     epi_data,
     outcome,
     predictors = outcome,
-    trainer = NULL,
+    trainer = parsnip::linear_reg(),
     args_list = arx_args_list()) {
   # --- validation
   validate_forecaster_inputs(epi_data, outcome, predictors)

--- a/man/arx_class_epi_workflow.Rd
+++ b/man/arx_class_epi_workflow.Rd
@@ -8,7 +8,7 @@ arx_class_epi_workflow(
   epi_data,
   outcome,
   predictors,
-  trainer = NULL,
+  trainer = parsnip::logistic_reg(),
   args_list = arx_class_args_list()
 )
 }
@@ -28,11 +28,11 @@ specifically mentioned will be used. (The \code{outcome} will not be added.)
 By default, equals the outcome. If manually specified, does not add the
 outcome variable, so make sure to specify it.}
 
-\item{trainer}{A \code{{parsnip}} model describing the type of estimation.
-For now, we enforce \code{mode = "classification"}. Typical values are
+\item{trainer}{A \code{{parsnip}} model describing the type of estimation. For
+now, we enforce \code{mode = "classification"}. Typical values are
 \code{\link[parsnip:logistic_reg]{parsnip::logistic_reg()}} or \code{\link[parsnip:multinom_reg]{parsnip::multinom_reg()}}. More complicated
-trainers like \code{\link[parsnip:naive_Bayes]{parsnip::naive_Bayes()}} or \code{\link[parsnip:rand_forest]{parsnip::rand_forest()}} can
-also be used. May be \code{NULL} (the default).}
+trainers like \code{\link[parsnip:naive_Bayes]{parsnip::naive_Bayes()}} or \code{\link[parsnip:rand_forest]{parsnip::rand_forest()}} can also
+be used. May be \code{NULL} if you'd like to decide later.}
 
 \item{args_list}{A list of customization arguments to determine
 the type of forecasting model. See \code{\link[=arx_class_args_list]{arx_class_args_list()}}.}

--- a/man/arx_fcast_epi_workflow.Rd
+++ b/man/arx_fcast_epi_workflow.Rd
@@ -8,7 +8,7 @@ arx_fcast_epi_workflow(
   epi_data,
   outcome,
   predictors = outcome,
-  trainer = NULL,
+  trainer = parsnip::linear_reg(),
   args_list = arx_args_list()
 )
 }
@@ -24,8 +24,9 @@ specifically mentioned will be used. (The \code{outcome} will not be added.)
 By default, equals the outcome. If manually specified, does not add the
 outcome variable, so make sure to specify it.}
 
-\item{trainer}{A \code{{parsnip}} model describing the type of estimation.
-For now, we enforce \code{mode = "regression"}. May be \code{NULL} (the default).}
+\item{trainer}{A \code{{parsnip}} model describing the type of estimation. For
+now, we enforce \code{mode = "regression"}. May be \code{NULL} if you'd like to
+decide later.}
 
 \item{args_list}{A list of customization arguments to determine
 the type of forecasting model. See \code{\link[=arx_args_list]{arx_args_list()}}.}

--- a/man/autoplot-epipred.Rd
+++ b/man/autoplot-epipred.Rd
@@ -39,20 +39,11 @@ More than 3 levels begins to be difficult to see.}
 
 \item{...}{Ignored}
 
-\item{.color_by}{Which variables should determine the color(s) used to plot
-lines. Options include:
-\itemize{
-\item \code{all_keys} - the default uses the interaction of any key variables
-including the \code{geo_value}
-\item \code{geo_value} - \code{geo_value} only
-\item \code{other_keys} - any available keys that are not \code{geo_value}
-\item \code{.response} - the numeric variables (same as the y-axis)
-\item \code{all} - uses the interaction of all keys and numeric variables
-\item \code{none} - no coloring aesthetic is applied
-}}
+\item{.color_by}{A character string indicating how to color the data. See
+\code{epiprocess::autoplot.epi_df()} for more details.}
 
-\item{.facet_by}{Similar to \code{.color_by} except that the default is to
-display the response.}
+\item{.facet_by}{A character string indicating how to facet the data. See
+\code{epiprocess::autoplot.epi_df()} for more details.}
 
 \item{.base_color}{If available, prediction bands will be shown with this
 color.}
@@ -60,8 +51,8 @@ color.}
 \item{.point_pred_color}{If available, point forecasts will be shown with
 this color.}
 
-\item{.max_facets}{Cut down of the number of facets displayed. Especially
-useful for testing when there are many \code{geo_value}'s or keys.}
+\item{.max_facets}{The maximum number of facets to show. If the number of
+facets is greater than this value, only the top facets will be shown.}
 }
 \description{
 For a fit workflow, the training data will be displayed, the response by

--- a/man/autoplot-epipred.Rd
+++ b/man/autoplot-epipred.Rd
@@ -39,11 +39,20 @@ More than 3 levels begins to be difficult to see.}
 
 \item{...}{Ignored}
 
-\item{.color_by}{A character string indicating how to color the data. See
-\code{epiprocess::autoplot.epi_df()} for more details.}
+\item{.color_by}{Which variables should determine the color(s) used to plot
+lines. Options include:
+\itemize{
+\item \code{all_keys} - the default uses the interaction of any key variables
+including the \code{geo_value}
+\item \code{geo_value} - \code{geo_value} only
+\item \code{other_keys} - any available keys that are not \code{geo_value}
+\item \code{.response} - the numeric variables (same as the y-axis)
+\item \code{all} - uses the interaction of all keys and numeric variables
+\item \code{none} - no coloring aesthetic is applied
+}}
 
-\item{.facet_by}{A character string indicating how to facet the data. See
-\code{epiprocess::autoplot.epi_df()} for more details.}
+\item{.facet_by}{Similar to \code{.color_by} except that the default is to
+display the response.}
 
 \item{.base_color}{If available, prediction bands will be shown with this
 color.}
@@ -51,8 +60,8 @@ color.}
 \item{.point_pred_color}{If available, point forecasts will be shown with
 this color.}
 
-\item{.max_facets}{The maximum number of facets to show. If the number of
-facets is greater than this value, only the top facets will be shown.}
+\item{.max_facets}{Cut down of the number of facets displayed. Especially
+useful for testing when there are many \code{geo_value}'s or keys.}
 }
 \description{
 For a fit workflow, the training data will be displayed, the response by


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main".
- [x] Request a review from one of the current epipredict main reviewers:
      dajmcdon.
- [x] Make sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
      Always increment the patch version number (the third number), unless you are
      making a release PR from dev to main, in which case increment the minor
      version number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      0.7.2, then write your changes under the 0.8 heading).
- [x] Consider pinning the `epiprocess` version in the `DESCRIPTION` file if
  - You anticipate breaking changes in `epiprocess` soon
  - You want to co-develop features in `epipredict` and `epiprocess`

### Change explanations for reviewer

`arx_fcast_epi_workflow()` and `arx_class_epi_workflow()` now default to `trainer = parsnip::logistic_reg()` to match their more canned versions.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

