### PR TITLE
refactor: epi_recipe only accepts epi_df

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epipredict
 Title: Basic epidemiology forecasting methods
-Version: 0.0.15
+Version: 0.0.16
 Authors@R: c(
     person("Daniel", "McDonald", , "daniel@stat.ubc.ca", role = c("aut", "cre")),
     person("Ryan", "Tibshirani", , "ryantibs@cmu.edu", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,7 @@ Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.0.x will indicat
 - `arx_fcast_epi_workflow()` and `arx_class_epi_workflow()` now default to
   `trainer = parsnip::logistic_reg()` to match their more canned versions.
 - add a `forecast()` method simplify generating forecasts
-- refactor `bake.epi_recipe()` and remove `epi_juice()`. 
-- Revise `compat-purrr` to use the r-lang `standalone-*` version (via 
+- refactor `bake.epi_recipe()` and remove `epi_juice()`.
+- Revise `compat-purrr` to use the r-lang `standalone-*` version (via
   `{usethis}`)
+- `epi_recipe()` will now warn when given non-`epi_df` data

--- a/R/epi_recipe.R
+++ b/R/epi_recipe.R
@@ -20,6 +20,10 @@ epi_recipe.default <- function(x, ...) {
   if (is.matrix(x) || is.data.frame(x) || tibble::is_tibble(x)) {
     x <- x[1, , drop = FALSE]
   }
+  cli_warn(
+    "epi_recipe has been called with a non-epi_df object, returning a regular recipe. Various
+    step_epi_* functions will not work."
+  )
   recipes::recipe(x, ...)
 }
 
@@ -147,6 +151,10 @@ epi_recipe.formula <- function(formula, data, ...) {
   data <- data[1, ]
   # check for minus:
   if (!epiprocess::is_epi_df(data)) {
+    cli_warn(
+      "epi_recipe has been called with a non-epi_df object, returning a regular recipe. Various
+    step_epi_* functions will not work."
+    )
     return(recipes::recipe(formula, data, ...))
   }
 
@@ -333,15 +341,11 @@ update_epi_recipe <- function(x, recipe, ..., blueprint = default_epi_recipe_blu
 #' illustrations of the different types of updates.
 #'
 #' @param x A `epi_workflow` or `epi_recipe` object
-#'
 #' @param which_step the number or name of the step to adjust
-#'
 #' @param ... Used to input a parameter adjustment
-#'
 #' @param blueprint A hardhat blueprint used for fine tuning the preprocessing.
 #'
-#' @return
-#' `x`, updated with the adjustment to the specified `epi_recipe` step.
+#' @return `x`, updated with the adjustment to the specified `epi_recipe` step.
 #'
 #' @export
 #' @examples
@@ -383,8 +387,7 @@ adjust_epi_recipe <- function(x, which_step, ..., blueprint = default_epi_recipe
 
 #' @rdname adjust_epi_recipe
 #' @export
-adjust_epi_recipe.epi_workflow <- function(
-    x, which_step, ..., blueprint = default_epi_recipe_blueprint()) {
+adjust_epi_recipe.epi_workflow <- function(x, which_step, ..., blueprint = default_epi_recipe_blueprint()) {
   recipe <- adjust_epi_recipe(workflows::extract_preprocessor(x), which_step, ...)
 
   update_epi_recipe(x, recipe, blueprint = blueprint)
@@ -392,8 +395,7 @@ adjust_epi_recipe.epi_workflow <- function(
 
 #' @rdname adjust_epi_recipe
 #' @export
-adjust_epi_recipe.epi_recipe <- function(
-    x, which_step, ..., blueprint = default_epi_recipe_blueprint()) {
+adjust_epi_recipe.epi_recipe <- function(x, which_step, ..., blueprint = default_epi_recipe_blueprint()) {
   if (!(is.numeric(which_step) || is.character(which_step))) {
     cli::cli_abort(
       c("`which_step` must be a number or a character.",

--- a/tests/testthat/test-epi_recipe.R
+++ b/tests/testthat/test-epi_recipe.R
@@ -4,20 +4,23 @@ test_that("epi_recipe produces default recipe", {
     x = 1:5, y = 1:5,
     time_value = seq(as.Date("2020-01-01"), by = 1, length.out = 5)
   )
-  rec <- recipes::recipe(tib)
-  rec$template <- rec$template[1, ]
-  expect_identical(rec, epi_recipe(tib))
+  expected_rec <- recipes::recipe(tib)
+  expected_rec$template <- expected_rec$template[1, ]
+  expect_warning(rec <- epi_recipe(tib), regexp = "epi_recipe has been called with a non-epi_df object")
+  expect_identical(expected_rec, rec)
   expect_equal(nrow(rec$template), 1L)
 
-  rec <- recipes::recipe(y ~ x, tib)
-  rec$template <- rec$template[1, ]
-  expect_identical(rec, epi_recipe(y ~ x, tib))
+  expected_rec <- recipes::recipe(y ~ x, tib)
+  expected_rec$template <- expected_rec$template[1, ]
+  expect_warning(rec <- epi_recipe(y ~ x, tib), regexp = "epi_recipe has been called with a non-epi_df object")
+  expect_identical(expected_rec, rec)
   expect_equal(nrow(rec$template), 1L)
 
   m <- as.matrix(tib)
-  rec <- recipes::recipe(m)
-  rec$template <- rec$template[1, ]
-  expect_identical(rec, epi_recipe(m))
+  expected_rec <- recipes::recipe(m)
+  expected_rec$template <- expected_rec$template[1, ]
+  expect_warning(rec <- epi_recipe(m), regexp = "epi_recipe has been called with a non-epi_df object")
+  expect_identical(expected_rec, rec)
   expect_equal(nrow(rec$template), 1L)
 })
 


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main".
- [x] Request a review from one of the current epipredict main reviewers:
      dajmcdon.
- [x] Make sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
      Always increment the patch version number (the third number), unless you are
      making a release PR from dev to main, in which case increment the minor
      version number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      0.7.2, then write your changes under the 0.8 heading).
- [x] Consider pinning the `epiprocess` version in the `DESCRIPTION` file if
  - You anticipate breaking changes in `epiprocess` soon
  - You want to co-develop features in `epipredict` and `epiprocess`

### Change explanations for reviewer

Only allows epi_df in epi_recipe and everything else just gives a clear error as such. Open to conversation about this, I don't know if falling back to regular recipes is useful sometimes, I haven't needed that functionality, but if it's not, then this is the behavior I prefer.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #348
