### PR TITLE
feat: expose "method" arg of quantile_reg

### DIFF
--- a/R/make_quantile_reg.R
+++ b/R/make_quantile_reg.R
@@ -11,6 +11,8 @@
 #'   "rq" is supported.
 #' @param quantile_levels A scalar or vector of values in (0, 1) to determine which
 #'   quantiles to estimate (default is 0.5).
+#' @param method A fitting method used by [quantreg::rq()]. See the
+#'   documentation for a list of options.
 #'
 #' @export
 #'

--- a/man/quantile_reg.Rd
+++ b/man/quantile_reg.Rd
@@ -4,7 +4,12 @@
 \alias{quantile_reg}
 \title{Quantile regression}
 \usage{
-quantile_reg(mode = "regression", engine = "rq", quantile_levels = 0.5)
+quantile_reg(
+  mode = "regression",
+  engine = "rq",
+  quantile_levels = 0.5,
+  method = "br"
+)
 }
 \arguments{
 \item{mode}{A single character string for the type of model.
@@ -15,6 +20,9 @@ The only possible value for this model is "regression".}
 
 \item{quantile_levels}{A scalar or vector of values in (0, 1) to determine which
 quantiles to estimate (default is 0.5).}
+
+\item{method}{A fitting method used by \code{\link[quantreg:rq]{quantreg::rq()}}. See the
+documentation for a list of options.}
 }
 \description{
 \code{quantile_reg()} generates a quantile regression model \emph{specification} for


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main".
- [x] Request a review from one of the current epipredict main reviewers:
      dajmcdon.
- [ ] Make sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
      Always increment the patch version number (the third number), unless you are
      making a release PR from dev to main, in which case increment the minor
      version number (the second number).
- [ ] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      0.7.2, then write your changes under the 0.8 heading).
- [ ] Consider pinning the `epiprocess` version in the `DESCRIPTION` file if
  - You anticipate breaking changes in `epiprocess` soon
  - You want to co-develop features in `epipredict` and `epiprocess`

### Change explanations for reviewer

Allows us to choose the fitting method used by `quantilereg::rq`.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #{issue number}
