### PR TITLE
refactor: remove Suggests dependence on covidcast

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,6 @@ Imports:
     vctrs,
     workflows (>= 1.0.0)
 Suggests:
-    covidcast,
     data.table,
     epidatr (>= 1.0.0),
     fs,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,6 +60,7 @@ Suggests:
     quantreg,
     ranger,
     RcppRoll,
+    readr,
     rmarkdown,
     smoothqr,
     testthat (>= 3.0.0),

--- a/data-raw/case_death_rate_subset.R
+++ b/data-raw/case_death_rate_subset.R
@@ -1,9 +1,8 @@
 library(tidyverse)
-library(covidcast)
 library(epidatr)
 library(epiprocess)
 
-x <- covidcast(
+x <- pub_covidcast(
   data_source = "jhu-csse",
   signals = "confirmed_7dav_incidence_prop",
   time_type = "day",
@@ -11,10 +10,9 @@ x <- covidcast(
   time_values = epirange(20201231, 20211231),
   geo_values = "*"
 ) %>%
-  fetch() %>%
   select(geo_value, time_value, case_rate = value)
 
-y <- covidcast(
+y <- pub_covidcast(
   data_source = "jhu-csse",
   signals = "deaths_7dav_incidence_prop",
   time_type = "day",
@@ -22,7 +20,6 @@ y <- covidcast(
   time_values = epirange(20201231, 20211231),
   geo_values = "*"
 ) %>%
-  fetch() %>%
   select(geo_value, time_value, death_rate = value)
 
 case_death_rate_subset <- x %>%

--- a/data-raw/state_census.R
+++ b/data-raw/state_census.R
@@ -1,14 +1,10 @@
 library(dplyr)
 library(tidyr)
 
-remote_file <- "https://github.com/cmu-delphi/covidcast/raw/refs/heads/main/R-packages/covidcast/data/state_census.rda"
-download.file(remote_file, "state_census.rda")
-load("state_census.rda")
-state_census <- state_census %>%
+state_census <- read_csv("https://github.com/cmu-delphi/covidcast/raw/c89e4d295550ba1540d64d2cc991badf63ad04e5/Python-packages/covidcast-py/covidcast/geo_mappings/state_census.csv") %>%
   select(STATE, NAME, POPESTIMATE2019, ABBR) %>%
   rename(abbr = ABBR, name = NAME, pop = POPESTIMATE2019, fips = STATE) %>%
   mutate(abbr = tolower(abbr)) %>%
   as_tibble()
-file.remove("state_census.rda")
 
 usethis::use_data(state_census, overwrite = TRUE)

--- a/data-raw/state_census.R
+++ b/data-raw/state_census.R
@@ -1,11 +1,14 @@
 library(dplyr)
 library(tidyr)
 
-state_census <- covidcast::state_census %>%
+remote_file <- "https://github.com/cmu-delphi/covidcast/raw/refs/heads/main/R-packages/covidcast/data/state_census.rda"
+download.file(remote_file, "state_census.rda")
+load("state_census.rda")
+state_census <- state_census %>%
   select(STATE, NAME, POPESTIMATE2019, ABBR) %>%
   rename(abbr = ABBR, name = NAME, pop = POPESTIMATE2019, fips = STATE) %>%
   mutate(abbr = tolower(abbr)) %>%
   as_tibble()
-
+file.remove("state_census.rda")
 
 usethis::use_data(state_census, overwrite = TRUE)

--- a/data-raw/state_census.R
+++ b/data-raw/state_census.R
@@ -1,7 +1,7 @@
 library(dplyr)
 library(tidyr)
 
-state_census <- read_csv("https://github.com/cmu-delphi/covidcast/raw/c89e4d295550ba1540d64d2cc991badf63ad04e5/Python-packages/covidcast-py/covidcast/geo_mappings/state_census.csv") %>%
+state_census <- readr::read_csv("https://github.com/cmu-delphi/covidcast/raw/c89e4d295550ba1540d64d2cc991badf63ad04e5/Python-packages/covidcast-py/covidcast/geo_mappings/state_census.csv") %>% # nolint: line_length_linter
   select(STATE, NAME, POPESTIMATE2019, ABBR) %>%
   rename(abbr = ABBR, name = NAME, pop = POPESTIMATE2019, fips = STATE) %>%
   mutate(abbr = tolower(abbr)) %>%

--- a/tests/testthat/_snaps/population_scaling.md
+++ b/tests/testthat/_snaps/population_scaling.md
@@ -1,0 +1,16 @@
+# expect error if `by` selector does not match
+
+    Code
+      wf <- epi_workflow(r, parsnip::linear_reg()) %>% fit(jhu) %>% add_frosting(f)
+    Condition
+      Error in `hardhat::validate_column_names()`:
+      ! The following required columns are missing: 'a'.
+
+---
+
+    Code
+      forecast(wf)
+    Condition
+      Error in `hardhat::validate_column_names()`:
+      ! The following required columns are missing: 'nothere'.
+

--- a/tests/testthat/_snaps/step_epi_slide.md
+++ b/tests/testthat/_snaps/step_epi_slide.md
@@ -12,7 +12,7 @@
       r %>% step_epi_slide(value, .f = mean, .window_size = c(3L, 6L))
     Condition
       Error in `epiprocess:::validate_slide_window_arg()`:
-      ! Slide function expected `.window_size` to be a non-null, scalar integer >= 1.
+      ! Slide function expected `.window_size` to be a length-1 difftime with units in days or non-negative integer or Inf.
 
 ---
 
@@ -60,7 +60,7 @@
       r %>% step_epi_slide(value, .f = mean, .window_size = 1.5)
     Condition
       Error in `epiprocess:::validate_slide_window_arg()`:
-      ! Slide function expected `.window_size` to be a difftime with units in days or non-negative integer or Inf.
+      ! Slide function expected `.window_size` to be a length-1 difftime with units in days or non-negative integer or Inf.
 
 ---
 

--- a/tests/testthat/test-grf_quantiles.R
+++ b/tests/testthat/test-grf_quantiles.R
@@ -10,7 +10,7 @@ test_that("quantile_rand_forest defaults work", {
   expect_silent(out <- fit(spec, formula = y ~ x + z, data = tib))
   pars <- parsnip::extract_fit_engine(out)
   manual <- quantile_forest(as.matrix(tib[, 2:3]), tib$y, quantiles = c(0.1, 0.5, 0.9))
-  expect_identical(pars$quantiles.orig, manual$quantiles)
+  expect_identical(pars$quantiles.orig, manual$quantiles.orig)
   expect_identical(pars$`_num_trees`, manual$`_num_trees`)
 
   fseed <- 12345

--- a/tests/testthat/test-snapshots.R
+++ b/tests/testthat/test-snapshots.R
@@ -117,7 +117,7 @@ test_that("arx_forecaster output format snapshots", {
     jhu, "death_rate",
     c("case_rate", "death_rate")
   )
-  expect_equal(as.Date(out1$metadata$forecast_created), Sys.Date())
+  expect_equal(as.Date(format(out1$metadata$forecast_created, "%Y-%m-%d")), Sys.Date())
   out1$metadata$forecast_created <- as.Date("0999-01-01")
   expect_snapshot(out1)
   out2 <- arx_forecaster(jhu, "case_rate",
@@ -129,7 +129,7 @@ test_that("arx_forecaster output format snapshots", {
       forecast_date = as.Date("2022-01-03")
     )
   )
-  expect_equal(as.Date(out2$metadata$forecast_created), Sys.Date())
+  expect_equal(as.Date(format(out2$metadata$forecast_created, "%Y-%m-%d")), Sys.Date())
   out2$metadata$forecast_created <- as.Date("0999-01-01")
   expect_snapshot(out2)
   out3 <- arx_forecaster(jhu, "death_rate",
@@ -140,7 +140,7 @@ test_that("arx_forecaster output format snapshots", {
       forecast_date = as.Date("2022-01-03")
     )
   )
-  expect_equal(as.Date(out3$metadata$forecast_created), Sys.Date())
+  expect_equal(as.Date(format(out3$metadata$forecast_created, "%Y-%m-%d")), Sys.Date())
   out3$metadata$forecast_created <- as.Date("0999-01-01")
   expect_snapshot(out3)
 })


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main".
- [x] Request a review from one of the current epipredict main reviewers:
      dajmcdon.
- [ ] Make sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
      Always increment the patch version number (the third number), unless you are
      making a release PR from dev to main, in which case increment the minor
      version number (the second number).
- [ ] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      0.7.2, then write your changes under the 0.8 heading).
- [ ] Consider pinning the `epiprocess` version in the `DESCRIPTION` file if
  - You anticipate breaking changes in `epiprocess` soon
  - You want to co-develop features in `epipredict` and `epiprocess`

### Change explanations for reviewer

* just download the state data file, don't import covidcast
* covidcast depends on sf which is tough to install (it just refuses to compile on my machine) and my renv keeps trying to install ALL dependencies

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #{issue number}
