### PR TITLE
ci: fix pkgdown

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -8,8 +8,6 @@
 on:
   push:
     branches: [main, dev]
-  pull_request:
-    branches: [main, dev]
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,9 +1,14 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 #
-# Created with usethis + edited to run on PRs to dev, use API key.
+# Modifications:
+#   * workflow_dispatch added to allow manual triggering of the workflow
+#   * trigger branches changed
+#   * API key secrets.SECRET_EPIPREDICT_GHACTIONS_DELPHI_EPIDATA_KEY
 on:
   push:
+    branches: [main, dev]
+  pull_request:
     branches: [main, dev]
   release:
     types: [published]
@@ -21,8 +26,9 @@ jobs:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      DELPHI_EPIDATA_KEY: ${{ secrets.SECRET_EPIPREDICT_GHACTIONS_DELPHI_EPIDATA_KEY }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -32,19 +38,31 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: any::pkgdown, local::., any::cli
           needs: website
 
       - name: Build site
-        env:
-          DELPHI_EPIDATA_KEY: ${{ secrets.SECRET_EPIPROCESS_GHACTIONS_DELPHI_EPIDATA_KEY }}
+        # - target_ref gets the ref from a different variable, depending on the event
+        # - override allows us to set the pkgdown mode and version_label
+        #   - mode: release is the standard build mode, devel places the site in /dev
+        #   - version_label: 'light' and 'success' are CSS labels for Bootswatch: Cosmo
+        #                    https://bootswatch.com/cosmo/
+        # - we use pkgdown:::build_github_pages to build the site because of an issue in pkgdown
+        #   https://github.com/r-lib/pkgdown/issues/2257
         run: |
-          if (startsWith("${{ github.event_name }}", "pull_request")) {
-              mode <- ifelse("${{ github.base_ref }}" == "main", "release", "devel")
+          target_ref <- "${{ github.event_name == 'pull_request' && github.base_ref || github.ref }}"
+          override <- if (target_ref == "main" || target_ref == "refs/heads/main") {
+            list(development = list(mode = "release", version_label = "light"))
+          } else if (target_ref == "dev" || target_ref == "refs/heads/dev") {
+            list(development = list(mode = "devel", version_label = "success"))
           } else {
-              mode <- ifelse("${{ github.ref_name }}" == "main", "release", "devel")
+            stop("Unexpected target_ref: ", target_ref)
           }
-          pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, override=list(PKGDOWN_DEV_MODE=mode))
+          pkg <- pkgdown::as_pkgdown(".", override = override)
+          cli::cli_rule("Cleaning files from old site...")
+          pkgdown::clean_site(pkg)
+          pkgdown::build_site(pkg, preview = FALSE, install = FALSE, new_process = FALSE)
+          pkgdown:::build_github_pages(pkg)
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀

--- a/tests/testthat/_snaps/population_scaling.md
+++ b/tests/testthat/_snaps/population_scaling.md
@@ -1,0 +1,16 @@
+# expect error if `by` selector does not match
+
+    Code
+      wf <- epi_workflow(r, parsnip::linear_reg()) %>% fit(jhu) %>% add_frosting(f)
+    Condition
+      Error in `hardhat::validate_column_names()`:
+      ! The following required columns are missing: 'a'.
+
+---
+
+    Code
+      forecast(wf)
+    Condition
+      Error in `hardhat::validate_column_names()`:
+      ! The following required columns are missing: 'nothere'.
+

--- a/tests/testthat/_snaps/step_epi_slide.md
+++ b/tests/testthat/_snaps/step_epi_slide.md
@@ -12,7 +12,7 @@
       r %>% step_epi_slide(value, .f = mean, .window_size = c(3L, 6L))
     Condition
       Error in `epiprocess:::validate_slide_window_arg()`:
-      ! Slide function expected `.window_size` to be a non-null, scalar integer >= 1.
+      ! Slide function expected `.window_size` to be a length-1 difftime with units in days or non-negative integer or Inf.
 
 ---
 
@@ -60,7 +60,7 @@
       r %>% step_epi_slide(value, .f = mean, .window_size = 1.5)
     Condition
       Error in `epiprocess:::validate_slide_window_arg()`:
-      ! Slide function expected `.window_size` to be a difftime with units in days or non-negative integer or Inf.
+      ! Slide function expected `.window_size` to be a length-1 difftime with units in days or non-negative integer or Inf.
 
 ---
 

--- a/tests/testthat/test-grf_quantiles.R
+++ b/tests/testthat/test-grf_quantiles.R
@@ -10,7 +10,7 @@ test_that("quantile_rand_forest defaults work", {
   expect_silent(out <- fit(spec, formula = y ~ x + z, data = tib))
   pars <- parsnip::extract_fit_engine(out)
   manual <- quantile_forest(as.matrix(tib[, 2:3]), tib$y, quantiles = c(0.1, 0.5, 0.9))
-  expect_identical(pars$quantiles.orig, manual$quantiles)
+  expect_identical(pars$quantiles.orig, manual$quantiles.orig)
   expect_identical(pars$`_num_trees`, manual$`_num_trees`)
 
   fseed <- 12345

--- a/tests/testthat/test-snapshots.R
+++ b/tests/testthat/test-snapshots.R
@@ -117,7 +117,7 @@ test_that("arx_forecaster output format snapshots", {
     jhu, "death_rate",
     c("case_rate", "death_rate")
   )
-  expect_equal(as.Date(out1$metadata$forecast_created), Sys.Date())
+  expect_equal(as.Date(format(out1$metadata$forecast_created, "%Y-%m-%d")), Sys.Date())
   out1$metadata$forecast_created <- as.Date("0999-01-01")
   expect_snapshot(out1)
   out2 <- arx_forecaster(jhu, "case_rate",
@@ -129,7 +129,7 @@ test_that("arx_forecaster output format snapshots", {
       forecast_date = as.Date("2022-01-03")
     )
   )
-  expect_equal(as.Date(out2$metadata$forecast_created), Sys.Date())
+  expect_equal(as.Date(format(out2$metadata$forecast_created, "%Y-%m-%d")), Sys.Date())
   out2$metadata$forecast_created <- as.Date("0999-01-01")
   expect_snapshot(out2)
   out3 <- arx_forecaster(jhu, "death_rate",
@@ -140,7 +140,7 @@ test_that("arx_forecaster output format snapshots", {
       forecast_date = as.Date("2022-01-03")
     )
   )
-  expect_equal(as.Date(out3$metadata$forecast_created), Sys.Date())
+  expect_equal(as.Date(format(out3$metadata$forecast_created, "%Y-%m-%d")), Sys.Date())
   out3$metadata$forecast_created <- as.Date("0999-01-01")
   expect_snapshot(out3)
 })


### PR DESCRIPTION
### Checklist

Please:

- [ ] Make sure this PR is against "dev", not "main".
- [ ] Request a review from one of the current epipredict main reviewers:
      dajmcdon.
- [ ] Make sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
      Always increment the patch version number (the third number), unless you are
      making a release PR from dev to main, in which case increment the minor
      version number (the second number).
- [ ] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      0.7.2, then write your changes under the 0.8 heading).
- [ ] Consider pinning the `epiprocess` version in the `DESCRIPTION` file if
  - You anticipate breaking changes in `epiprocess` soon
  - You want to co-develop features in `epipredict` and `epiprocess`

### Change explanations for reviewer

The [documentation on main](https://cmu-delphi.github.io/epipredict/) didn't get updated as intended. This syncs the pkgdown action to what's used in [epiprocess](https://github.com/cmu-delphi/epiprocess/blob/dev/.github/workflows/pkgdown.yaml), where we're sure it works.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #{issue number}
