### PR TITLE
sorting unsorted quantiles

### DIFF
--- a/R/dist_quantiles.R
+++ b/R/dist_quantiles.R
@@ -15,6 +15,7 @@ new_quantiles <- function(values = double(1), quantile_levels = double(1)) {
     ))
   }
   stopifnot(length(values) == length(quantile_levels))
+  quantile_levels <- sort(quantile_levels)
 
   stopifnot(!vctrs::vec_duplicate_any(quantile_levels))
   if (is.unsorted(quantile_levels)) {
@@ -22,11 +23,8 @@ new_quantiles <- function(values = double(1), quantile_levels = double(1)) {
     values <- values[o]
     quantile_levels <- quantile_levels[o]
   }
-  if (is.unsorted(values, na.rm = TRUE)) {
-    cli_abort("`values[order(quantile_levels)]` produces unsorted quantiles.")
-  }
 
-  new_rcrd(list(values = values, quantile_levels = quantile_levels),
+  new_rcrd(list(values = values[order(quantile_levels)], quantile_levels = quantile_levels),
     class = c("dist_quantiles", "dist_default")
   )
 }
@@ -293,3 +291,4 @@ is.na.dist_quantiles <- function(x) {
   q <- field(x, "values")
   all(is.na(q))
 }
+


### PR DESCRIPTION
### Checklist

Please:

- [X] Make sure this PR is against "dev", not "main".
- [X] Request a review from one of the current epipredict main reviewers:
      dajmcdon.
- [ ] Make sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
      Always increment the patch version number (the third number), unless you are
      making a release PR from dev to main, in which case increment the minor
      version number (the second number).
- [ ] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      0.7.2, then write your changes under the 0.8 heading).
- [ ] Consider pinning the `epiprocess` version in the `DESCRIPTION` file if
  - You anticipate breaking changes in `epiprocess` soon
  - You want to co-develop features in `epipredict` and `epiprocess`

### Change explanations for reviewer

The quantile sorting issue continues to crop up somehow.
