### PR TITLE
Define `case_num` var when pulling data from `epidatasets` in symptoms survey vignette

### DIFF
--- a/vignettes/articles/smooth-qr.Rmd
+++ b/vignettes/articles/smooth-qr.Rmd
@@ -97,7 +97,7 @@ state cases and deaths. This sample data ranges from Dec. 31, 2020 to
 Dec. 31, 2021.
 
 ```{r}
-edf <- covid_case_death_rates
+edf <- epidatasets::covid_case_death_rates
 ```
 
 We will set the forecast date to be November 30, 2021 so that we can produce

--- a/vignettes/articles/symptom-surveys.Rmd
+++ b/vignettes/articles/symptom-surveys.Rmd
@@ -155,6 +155,7 @@ library(purrr)
 library(epipredict)
 library(recipes)
 
+case_num <- 200
 z <- epidatasets::county_smoothed_cli_comparison
 ```
 


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main".
- [x] Request a review from one of the current epipredict main reviewers:
      dajmcdon.
- [ ] Make sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
      Always increment the patch version number (the third number), unless you are
      making a release PR from dev to main, in which case increment the minor
      version number (the second number).
- [ ] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      0.7.2, then write your changes under the 0.8 heading).
- [ ] Consider pinning the `epiprocess` version in the `DESCRIPTION` file if
  - You anticipate breaking changes in `epiprocess` soon
  - You want to co-develop features in `epipredict` and `epiprocess`

### Change explanations for reviewer

Define `case_num` to keep vignette build from failing. Although it's no longer used for generating data, it is used in plot text.