### PR TITLE
fix(grab_forged_keys): don't pass geo & time as other_keys

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epipredict
 Title: Basic epidemiology forecasting methods
-Version: 0.1.5
+Version: 0.1.6
 Authors@R: c(
     person("Daniel J.", "McDonald", , "daniel@stat.ubc.ca", role = c("aut", "cre")),
     person("Ryan", "Tibshirani", , "ryantibs@cmu.edu", role = "aut"),

--- a/R/utils-misc.R
+++ b/R/utils-misc.R
@@ -80,9 +80,9 @@ grab_forged_keys <- function(forged, workflow, new_data) {
   # `epi_df` invariants.  Require that our key is a unique key in any case.
   if (all(c("geo_value", "time_value") %in% new_keys)) {
     maybe_as_of <- attr(new_data, "metadata")$as_of # NULL if wasn't epi_df
-    try(return(as_epi_df(new_key_tbl, other_keys = new_keys, as_of = maybe_as_of)),
-      silent = TRUE
-    )
+    new_other_keys <- new_keys[! new_keys %in% c("geo_value", "time_value")]
+    try(return(as_epi_df(new_key_tbl, other_keys = new_other_keys, as_of = maybe_as_of)),
+        silent = TRUE)
   }
   if (anyDuplicated(new_key_tbl)) {
     duplicate_key_tbl <- new_key_tbl %>% filter(.by = everything(), dplyr::n() > 1L)


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main".
- [x] Request a review from one of the current epipredict main reviewers:
      dajmcdon.
- [x] Make sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
      Always increment the patch version number (the third number), unless you are
      making a release PR from dev to main, in which case increment the minor
      version number (the second number).
- [-] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      0.7.2, then write your changes under the 0.8 heading).
  - This is a fix for an improvement under the 0.2 heading; it didn't make sense to write "fixed thing that didn't exist yet".
- [x] Consider pinning the `epiprocess` version in the `DESCRIPTION` file if
  - You anticipate breaking changes in `epiprocess` soon
  - You want to co-develop features in `epipredict` and `epiprocess`

### Change explanations for reviewer

`"geo_value"` and `"time_value"` were being passed as `other_keys` when trying to make grabbed forged keys into `epi_df`s.  This fixes that.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #{issue number}
