### PR TITLE
enh: pivot_quantiles_longer adds quantile_level to epi_df other_keys

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,12 +21,12 @@ Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.0.x will indicat
   `data(<dataset name>, package = "epidatasets")`, `epidatasets::<dataset name>`
   or, after loading the package, the name of the dataset alone (#382).
 - `step_adjust_latency()` no longer allows empty column selection.
-- Addresses upstream breaking changes from cmu-delphi/epiprocess#595 (`growth_rate()`). 
+- Addresses upstream breaking changes from cmu-delphi/epiprocess#595 (`growth_rate()`).
   `step_growth_rate()` has lost its `additional_gr_args_list` argument and now
   has an `na_rm` argument.
 - Moves `epiprocess` out of depends (#440). No internals have changed, but downstream
   users may need to add `library(epiprocess)` to existing code.
-- Removes dependence on the `distributional` package, replacing the quantiles 
+- Removes dependence on the `distributional` package, replacing the quantiles
   with `hardhat::quantile_pred()`. Some associated functions are deprecated with
   `lifecycle` messages.
 - Rename `check_enough_train_data()` to `check_enough_data()`, and generalize it
@@ -48,6 +48,8 @@ Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.0.x will indicat
 - Allow `quantile()` to threshold to an interval if desired (#434)
 - `arx_forecaster()` detects if there's enough data to predict
 - Add `observed_response` to `autoplot` so that forecasts can be plotted against the values they're predicting
+- `pivot_quantiles_longer()` now appropriately adds `quantile_level` to the
+  `epi_df` other keys
 
 ## Bug fixes
 

--- a/R/pivot_quantiles.R
+++ b/R/pivot_quantiles.R
@@ -80,8 +80,11 @@ pivot_quantiles_longer <- function(.data, ...) {
   long_tib <- as_tibble(.data[[col]])
   .data <- select(.data, !all_of(col))
   names(long_tib)[1:2] <- c(glue::glue("{col}_value"), glue::glue("{col}_quantile_level"))
-  left_join(.data, long_tib, by = ".row") %>%
-    select(!.row)
+  out <- left_join(.data, long_tib, by = ".row") %>% select(!.row)
+  if (inherits(.data, "epi_df")) {
+    attr(out, "metadata")$other_keys <- c(attr(.data, "metadata")$other_keys, glue::glue("{col}_quantile_level"))
+  }
+  out
 }
 
 #' @rdname pivot_quantiles

--- a/tests/testthat/test-pivot_quantiles.R
+++ b/tests/testthat/test-pivot_quantiles.R
@@ -45,6 +45,11 @@ test_that("quantile pivotting longer behaves", {
   expect_length(pivot_quantiles_longer(tib, d1), 4L)
   expect_identical(nrow(pivot_quantiles_longer(tib, d1)), 6L)
   expect_identical(pivot_quantiles_longer(tib, d1)$d1_value, c(1:3, 2:4))
+
+  # add quantile_level to epi_df other_keys, if epi_df
+  tib <- tibble(geo_value = c("a", "b"), time_value = as.Date(c("2021-01-01", "2021-01-02")), d1 = d1, d2 = d2)
+  epi_df <- tib %>% as_epi_df() %>% pivot_quantiles_longer(d1)
+  expect_equal(key_colnames(epi_df), c("geo_value","d1_quantile_level", "time_value"))
 })
 
 test_that("nested_quantiles is deprecated, but works where possible", {


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main".
- [x] Request a review from one of the current epipredict main reviewers:
      dajmcdon.
- [x] Make sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
      Always increment the patch version number (the third number), unless you are
      making a release PR from dev to main, in which case increment the minor
      version number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      0.7.2, then write your changes under the 0.8 heading).
- [ ] Consider pinning the `epiprocess` version in the `DESCRIPTION` file if
  - You anticipate breaking changes in `epiprocess` soon
  - You want to co-develop features in `epipredict` and `epiprocess`

### Change explanations for reviewer

Ran across this issue when writing YJ tests:

```r
r$> # add quantile_level to epi_df other_keys, if epi_df
      tib <- tibble(geo_value = c("a", "b"), time_value = as.Date(c("2021-01-01", "202
    1-01-02")), d1 = d1, d2 = d2)

r$> epi_df <- tib %>% as_epi_df() %>% pivot_quantiles_longer(d1)

r$> epi_df
An `epi_df` object, 6 x 5 with metadata:
* geo_type  = custom
* time_type = day
* as_of     = 2025-04-10 15:11:56.915382

# A tibble: 6 × 5
  geo_value time_value        d2 d1_value d1_quantile_level
  <chr>     <date>     <qtls(3)>    <int>             <dbl>
1 a         2021-01-01     [2.5]        1              0.25
2 a         2021-01-01     [2.5]        2              0.5 
3 a         2021-01-01     [2.5]        3              0.75
4 b         2021-01-02     [3.5]        2              0.25
5 b         2021-01-02     [3.5]        3              0.5 
6 b         2021-01-02     [3.5]        4              0.75
```

Not a big deal, but probably good to strive for epi_df key uniqueness, rather than breaking the model.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #{issue number}
