### PR TITLE
Fix flusight hub formatter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epipredict
 Title: Basic epidemiology forecasting methods
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(
     person("Daniel J.", "McDonald", , "daniel@stat.ubc.ca", role = c("aut", "cre")),
     person("Ryan", "Tibshirani", , "ryantibs@cmu.edu", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
-# epipredict 0.2.1
-
-- Fix bug in `flusight_hub_formatter()` so that it works as expected even if the user has not first loaded the `epidatasets` package.
-
 # epipredict (development)
 
 Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.0.x will indicate PR's.
+
+# epipredict 0.2.1
+
+- Fix bug in `flusight_hub_formatter()` so that it works as expected even if the user has not first loaded the `epidatasets` package.
 
 # epipredict 0.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# epipredict 0.2.1
+
 # epipredict (development)
 
 Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.0.x will indicate PR's.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # epipredict 0.2.1
 
+- Fix bug in `flusight_hub_formatter()` so that it works as expected even if the user has not first loaded the `epidatasets` package.
+
 # epipredict (development)
 
 Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.0.x will indicate PR's.

--- a/R/flusight_hub_formatter.R
+++ b/R/flusight_hub_formatter.R
@@ -1,6 +1,6 @@
 location_to_abbr <- function(location) {
   dictionary <-
-    state_census %>%
+    epidatasets::state_census %>%
     dplyr::transmute(
       location = dplyr::case_match(fips, "00" ~ "US", .default = fips),
       abbr
@@ -10,7 +10,7 @@ location_to_abbr <- function(location) {
 
 abbr_to_location <- function(abbr) {
   dictionary <-
-    state_census %>%
+    epidatasets::state_census %>%
     dplyr::transmute(
       location = dplyr::case_match(fips, "00" ~ "US", .default = fips),
       abbr
@@ -62,7 +62,7 @@ abbr_to_location <- function(abbr) {
 #'     geo_value %in% c("ca", "ny", "dc", "ga", "vt")
 #'   ) %>%
 #'   select(geo_value, time_value, death_rate) %>%
-#'   left_join(state_census %>% select(pop, abbr), by = c("geo_value" = "abbr")) %>%
+#'   left_join(epidatasets::state_census %>% select(pop, abbr), by = c("geo_value" = "abbr")) %>%
 #'   mutate(deaths = pmax(death_rate / 1e5 * pop * 7, 0)) %>%
 #'   select(-pop, -death_rate) %>%
 #'   group_by(geo_value) %>%

--- a/R/flusight_hub_formatter.R
+++ b/R/flusight_hub_formatter.R
@@ -62,7 +62,7 @@ abbr_to_location <- function(abbr) {
 #'     geo_value %in% c("ca", "ny", "dc", "ga", "vt")
 #'   ) %>%
 #'   select(geo_value, time_value, death_rate) %>%
-#'   left_join(epidatasets::state_census %>% select(pop, abbr), by = c("geo_value" = "abbr")) %>%
+#'   left_join(state_census %>% select(pop, abbr), by = c("geo_value" = "abbr")) %>%
 #'   mutate(deaths = pmax(death_rate / 1e5 * pop * 7, 0)) %>%
 #'   select(-pop, -death_rate) %>%
 #'   group_by(geo_value) %>%

--- a/man/autoplot-epipred.Rd
+++ b/man/autoplot-epipred.Rd
@@ -75,7 +75,7 @@ this color.}
 
 \item{.facet_filter}{Select which facets will be displayed. Especially
 useful for when there are many \code{geo_value}'s or keys. This is a
-<\code{\link[=args_data_masking]{rlang}}> expression along the lines of \code{\link[dplyr:filter]{dplyr::filter()}}.
+<\code{\link[rlang:args_data_masking]{rlang}}> expression along the lines of \code{\link[dplyr:filter]{dplyr::filter()}}.
 However, it must be a single expression combined with the \code{&} operator. This
 contrasts to the typical use case which allows multiple comma-separated expressions
 which are implicitly combined with \code{&}. When multiple variables are selected

--- a/man/step_adjust_latency.Rd
+++ b/man/step_adjust_latency.Rd
@@ -17,11 +17,11 @@ step_adjust_latency(
 )
 }
 \arguments{
-\item{recipe}{A recipe object. The step will be added to the
-sequence of operations for this recipe.}
+\item{recipe}{A recipe object. The step will be added to the sequence of
+operations for this recipe.}
 
-\item{...}{One or more selector functions to choose variables
-for this step. See \code{\link[recipes:selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables for this step.
+See \code{\link[recipes:selections]{selections()}} for more details.}
 
 \item{method}{a character. Determines the method by which the
 forecast handles latency. The options are:


### PR DESCRIPTION
### Checklist

Please:

- [x] Make sure this PR is against "dev", not "main".
- [x] Request a review from one of the current epipredict main reviewers:
      dajmcdon.
- [x] Make sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
      Always increment the patch version number (the third number), unless you are
      making a release PR from dev to main, in which case increment the minor
      version number (the second number).
- [x] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      0.7.2, then write your changes under the 0.8 heading).
- [x] Consider pinning the `epiprocess` version in the `DESCRIPTION` file if
  - You anticipate breaking changes in `epiprocess` soon
  - You want to co-develop features in `epipredict` and `epiprocess`

### Change explanations for reviewer
Qualifies the namespace for `epidatasets::state_census` in two internal functions. The alternative would be to import that name, but qualifying the namespace seems better given that it is only used twice in the codebase.

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch

- Resolves #469 