### PR TITLE
fix: display latency adjustment info on canned forecasters (#447)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,6 @@
 ^.lintr$
 ^.venv$
 ^inst/templates$
+^\.workflow$
+^\.plans$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ inst/doc
 renv.lock
 renv/
 .Renviron
+.workflow/
+.plans/
+.claude/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epipredict
 Title: Basic epidemiology forecasting methods
-Version: 0.2.2
+Version: 0.2.3
 Authors@R: c(
     person("Daniel J.", "McDonald", , "daniel@stat.ubc.ca", role = c("aut", "cre")),
     person("Ryan", "Tibshirani", , "ryantibs@cmu.edu", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.0.x will indicate PR's.
 
+# epipredict 0.2.3
+
+- Fix `print.canned_epipred()` so the latency-adjustment information actually displays for canned forecasters that include `step_adjust_latency` in their recipe (#447).
+
 # epipredict 0.2.2
 
 - Fix `autoplot.epi_workflow()` to correctly handle the response variable and avoid errors related to `.response`.

--- a/R/canned-epipred.R
+++ b/R/canned-epipred.R
@@ -112,7 +112,7 @@ print.canned_epipred <- function(x, name, ...) {
     "At forecast date{?s}: {.val {fds}},",
     "For target date{?s}: {.val {tds}},"
   ))
-  if ("pre" %in% names(x) && "actions" %in% names(x$pre) && "recipe" %in% names(x$pre$actions)) {
+  if (!is.null(x$epi_workflow$pre$actions$recipe)) {
     fit_recipe <- extract_recipe(x$epi_workflow)
     if (detect_step(fit_recipe, "adjust_latency")) {
       is_adj_latency <- map_lgl(fit_recipe$steps, function(x) inherits(x, "step_adjust_latency"))

--- a/tests/testthat/_snaps/snapshots.md
+++ b/tests/testthat/_snaps/snapshots.md
@@ -727,6 +727,7 @@
       * 56 unique geographic regions,
       * At forecast date: 2022-01-03,
       * For target date: 2022-01-10,
+      * Lags adjusted per column: case_rate=3, death_rate=3
       
 
 ---
@@ -750,6 +751,7 @@
       * 56 unique geographic regions,
       * At forecast date: 2022-01-03,
       * For target date: 2022-01-10,
+      * Aheads adjusted for death_rate=3
       
 
 # arx_classifier snapshots

--- a/tests/testthat/test-snapshots.R
+++ b/tests/testthat/test-snapshots.R
@@ -132,6 +132,10 @@ test_that("arx_forecaster output format snapshots", {
   expect_equal(as.Date(format(out2$metadata$forecast_created, "%Y-%m-%d")), Sys.Date())
   out2$metadata$forecast_created <- as.Date("1999-01-01")
   expect_snapshot(out2)
+  expect_match(
+    paste(testthat::capture_messages(print(out2)), collapse = ""),
+    "adjusted"
+  )
   out3 <- arx_forecaster(jhu, "death_rate",
     c("case_rate", "death_rate"),
     trainer = quantile_reg(),
@@ -143,6 +147,10 @@ test_that("arx_forecaster output format snapshots", {
   expect_equal(as.Date(format(out3$metadata$forecast_created, "%Y-%m-%d")), Sys.Date())
   out3$metadata$forecast_created <- as.Date("1999-01-01")
   expect_snapshot(out3)
+  expect_match(
+    paste(testthat::capture_messages(print(out3)), collapse = ""),
+    "adjusted"
+  )
 })
 
 test_that("arx_classifier snapshots", {


### PR DESCRIPTION
Resolves #447.

## Summary

`print.canned_epipred()` was supposed to surface latency-adjustment information (e.g., `Aheads adjusted per column: case_rate=2, death_rate=3`) for canned forecasters whose recipe contains a `step_adjust_latency`. It never actually did, because the gating conditional checked for a top-level `pre` field on the canned forecaster object — but canned forecasters' top-level fields are `predictions`, `epi_workflow`, and `metadata`. The conditional was always FALSE, and the entire latency-info block was dead code.

The fix replaces the conditional with `!is.null(x$epi_workflow$pre$actions$recipe)`, which correctly tests for a recipe preprocessor on the embedded workflow. The latency-info display now works for all four recipe-based canned forecasters (`arx_forecaster`, `arx_classifier`, `cdc_baseline_forecaster`, `flatline_forecaster`); `climatological_forecaster` correctly remains unaffected (it overwrites `pre` with a `mold`-only list and has no `step_adjust_latency`).

## Test coverage

The existing snapshot tests in `tests/testthat/test-snapshots.R` already exercised `arx_forecaster` with `adjust_latency = "extend_lags"` (`out2`) and `"extend_ahead"` (`out3`) but never observed the latency line because of the bug. Their snapshots regenerate to include the new lines (one `+` line each in `_snaps/snapshots.md` — purely additive). Two supplementary `expect_match("adjusted", ...)` assertions are added next to those snapshot calls as defensive guards: if a future contributor mechanically `snapshot_accept`s after an unrelated upstream change drops the "adjusted" line, the explicit assertions still catch the regression.

## Bookkeeping

- `NEWS.md`: new `# epipredict 0.2.3` section with one bullet.
- `DESCRIPTION`: version bumped to 0.2.3.
- `.gitignore` and `.Rbuildignore`: 3 lines each adding `.workflow/`, `.plans/`, and `.claude/` to keep personal tooling directories out of git tracking and out of the package build tarball. Happy to split into a separate PR if you prefer.

## Out of scope

The original issue mentions a broader concern about partial-matching vulnerabilities in `epi_archive` / `epi_df` list subclasses. Those types live in `epiprocess`, not `epipredict`. Within this repo, I confirmed via grep that `R/canned-epipred.R:115` was the only `x$pre` access where `x` was not a workflow object; the others (`R/epi_recipe.R:308`, `R/extract.R:88`, `R/model-methods.R:89`) all operate on workflow objects where `pre` is the actual field name. A broader audit belongs as a follow-up `epiprocess` issue.

## Test plan

- `devtools::test()` — 910 passing, 0 failing, 2 skips. The skips (`test-get_test_data.R:47` "NA fill behaves as desired" and `:85` "forecast date behaves") are pre-existing on `dev`, added in commit `09fbfd812` (July 2024) as placeholders during the locf-into-`step_adjust_ahead` refactor; the underlying `get_test_data` rework is tracked by PR #463 and issues #468 / #267.
- `devtools::check(document = FALSE, vignettes = FALSE)` — 0 errors. 1 environmental warning (`parsnip` binary built under R 4.5.2 vs local R 4.5.0 — won't fire in CI). 2 pre-existing notes on `dev` (top-level `Makefile`/`pkgdown-watch.R`, deep `:::` import list).
- `lintr::lint_package()` — zero new findings on lines added by this PR.
- Manually verified before/after: `arx_forecaster` with `step_adjust_latency` now shows the latency-adjustment bullet at the bottom of `print()` output.
