### PR TITLE
fix: `arx_forecaster()` cli template error on inconsistent target_date (#473)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epipredict
 Title: Basic epidemiology forecasting methods
-Version: 0.2.4
+Version: 0.2.5
 Authors@R: c(
     person("Daniel J.", "McDonald", , "daniel@stat.ubc.ca", role = c("aut", "cre")),
     person("Ryan", "Tibshirani", , "ryantibs@cmu.edu", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.0.x will indicate PR's.
 
+# epipredict 0.2.5
+
+- Fix `arx_forecaster()` and `arx_fcast_epi_workflow()` so that the error raised when `forecast_date + ahead != target_date` reports the actual validation message rather than a cryptic `cli` template-evaluation error (#473).
+
 # epipredict 0.2.4
 
 - Fix `flatline_forecaster()` to return one prediction per geographic key when the input `epi_df` has trailing rows with `NA`s in the outcome (#454). Previously, the forecast was duplicated once per trailing-NA day.

--- a/R/arx_forecaster.R
+++ b/R/arx_forecaster.R
@@ -144,7 +144,7 @@ arx_fcast_epi_workflow <- function(
   forecast_date <- args_list$forecast_date %||% forecast_date_default
   target_date <- args_list$target_date %||% (forecast_date + args_list$ahead)
   if (forecast_date + args_list$ahead != target_date) {
-    cli_abort("`forecast_date` {.val {forecast_date}} + `ahead` {.val {ahead}} must equal `target_date` {.val {target_date}}.",
+    cli_abort("`forecast_date` {.val {forecast_date}} + `ahead` {.val {args_list$ahead}} must equal `target_date` {.val {target_date}}.",
       class = "epipredict__arx_forecaster__inconsistent_target_ahead_forecaste_date"
     )
   }

--- a/tests/testthat/test-arx_forecaster.R
+++ b/tests/testthat/test-arx_forecaster.R
@@ -43,3 +43,18 @@ test_that("warns if there's not enough data to predict", {
     class = "epipredict__not_enough_data"
   )
 })
+
+test_that("arx_forecaster errors with documented class when forecast_date + ahead != target_date (issue #473)", {
+  df <- tibble(
+    geo_value = "ri",
+    time_value = seq.Date(as.Date("2026-01-01"), as.Date("2026-01-31"), by = "day"),
+    value = 0
+  ) %>%
+    as_epi_df(as_of = as.Date("2026-02-10"))
+  expect_error(
+    arx_forecaster(df, "value",
+      args_list = arx_args_list(target_date = as.Date("2026-02-17"))
+    ),
+    class = "epipredict__arx_forecaster__inconsistent_target_ahead_forecaste_date"
+  )
+})


### PR DESCRIPTION
Resolves #473. When `args_list = arx_args_list(target_date = ...)` produces `forecast_date + ahead != target_date`, the validation error inside `arx_fcast_epi_workflow()` was short-circuited by a broken `cli` template: the message at `R/arx_forecaster.R:147` referenced `{ahead}`, but inside that function the value lives at `args_list$ahead`. Users saw `Could not evaluate cli {} expression: 'ahead' not found` instead of the documented validation error. Fix: change `{.val {ahead}}` → `{.val {args_list$ahead}}` on that line; the error now fires with class `epipredict__arx_forecaster__inconsistent_target_ahead_forecaste_date` and a message naming all three values.

The sibling template at line 335 (inside `arx_args_list()`) is unchanged — there `ahead` is a formal argument. Note: draft PRs #463 and #403 also touch this `cli_abort` line for unrelated reasons; both will need a routine three-way rebase when they revive.