### PR TITLE
chore: regenerate roxygen-derived `man/step_adjust_latency.Rd`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epipredict
 Title: Basic epidemiology forecasting methods
-Version: 0.2.5
+Version: 0.2.6
 Authors@R: c(
     person("Daniel J.", "McDonald", , "daniel@stat.ubc.ca", role = c("aut", "cre")),
     person("Ryan", "Tibshirani", , "ryantibs@cmu.edu", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 Pre-1.0.0 numbering scheme: 0.x will indicate releases, while 0.0.x will indicate PR's.
 
+# epipredict 0.2.6
+
+- Regenerate roxygen-derived `man/step_adjust_latency.Rd` so its recorded example output matches the current `epi_df` print phrasing (`lag` → `latency`) from upstream `epiprocess`. No user-visible behavior change.
+
 # epipredict 0.2.5
 
 - Fix `arx_forecaster()` and `arx_fcast_epi_workflow()` so that the error raised when `forecast_date + ahead != target_date` reports the actual validation message rather than a cryptic `cli` template-evaluation error (#473).

--- a/man/step_adjust_latency.Rd
+++ b/man/step_adjust_latency.Rd
@@ -141,8 +141,8 @@ toy_recipe \%>\%
 #> * geo_type  = state
 #> * time_type = day
 #> * as_of     = 2015-01-14
-#> Latency (lag between last available observation and epi_df's as_of, by time series):
-#> * lag across all time series = 0 days
+#> Latency (time between last available observation and epi_df's as_of, by time series):
+#> * latency across all time series = 0 days
 #> 
 #> # A tibble: 8 x 4
 #>   geo_value time_value     a     b
@@ -179,8 +179,8 @@ toy_recipe \%>\%
 #> * geo_type  = state
 #> * time_type = day
 #> * as_of     = 2015-01-14
-#> Latency (lag between last available observation and epi_df's as_of, by time series):
-#> * lag  = -2–3 days
+#> Latency (time between last available observation and epi_df's as_of, by time series):
+#> * latency  = -2–3 days
 #> 
 #> # A tibble: 21 x 7
 #>    geo_value time_value     a     b lag_3_a lag_4_b ahead_1_a
@@ -229,8 +229,8 @@ toy_recipe \%>\%
 #> * geo_type  = state
 #> * time_type = day
 #> * as_of     = 2015-01-14
-#> Latency (lag between last available observation and epi_df's as_of, by time series):
-#> * lag  = 1–5 days
+#> Latency (time between last available observation and epi_df's as_of, by time series):
+#> * latency  = 1–5 days
 #> 
 #> # A tibble: 10 x 6
 #>    geo_value time_value     a     b lag_0_a ahead_3_a


### PR DESCRIPTION
Regeneration of `man/step_adjust_latency.Rd` via `devtools::document()`. The recorded example output had drifted relative to the current `epi_df` print phrasing (`lag` → `latency`) from upstream `epiprocess`; running `document()` updates 12 lines across three example blocks. No source code or behavior change. The drift surfaced during recent fix PRs (#477, #478, #479).