### PR TITLE
Reinclusion of `.max_keys = Inf` in `autoplot.epi_workflow`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     checkmate,
     cli,
     dplyr,
-    epiprocess (>= 0.12.0),
+    epiprocess (>= 0.13.0),
     generics,
     ggplot2,
     glue,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -72,7 +72,7 @@ Remotes:
     cmu-delphi/delphidocs,
     cmu-delphi/epidatasets,
     cmu-delphi/epidatr,
-    cmu-delphi/epiprocess,
+    cmu-delphi/epiprocess@dev,
     dajmcdon/smoothqr
 Config/Needs/website: cmu-delphi/delphidocs
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     checkmate,
     cli,
     dplyr,
-    epiprocess (>= 0.11.2),
+    epiprocess (>= 0.12.0),
     generics,
     ggplot2,
     glue,
@@ -72,7 +72,7 @@ Remotes:
     cmu-delphi/delphidocs,
     cmu-delphi/epidatasets,
     cmu-delphi/epidatr,
-    cmu-delphi/epiprocess@dev,
+    cmu-delphi/epiprocess,
     dajmcdon/smoothqr
 Config/Needs/website: cmu-delphi/delphidocs
 Config/testthat/edition: 3

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -171,7 +171,9 @@ autoplot.epi_workflow <- function(
       .color_by = .color_by,
       .facet_by = .facet_by,
       .base_color = .base_color,
-      .facet_filter = {{ .facet_filter }}
+      .facet_filter = {{ .facet_filter }},
+      # Avoid subsampling while it is not implemented for this method
+      .max_keys = Inf
     ))
   }
 
@@ -196,7 +198,9 @@ autoplot.epi_workflow <- function(
       .color_by = .color_by,
       .facet_by = .facet_by,
       .base_color = .base_color,
-      .facet_filter = {{ .facet_filter }}
+      .facet_filter = {{ .facet_filter }},
+      # Avoid subsampling while it is not implemented for this method
+      .max_keys = Inf
     ))
   }
 
@@ -207,7 +211,9 @@ autoplot.epi_workflow <- function(
     .color_by = "none",
     .facet_by = "all_keys",
     .base_color = "black",
-    .facet_filter = {{ .facet_filter }}
+    .facet_filter = {{ .facet_filter }},
+    # Avoid subsampling while it is not implemented for this method
+    .max_keys = Inf
   )
 
   # Now, prepare matching facets in the predictions

--- a/R/pivot_quantiles.R
+++ b/R/pivot_quantiles.R
@@ -82,7 +82,12 @@ pivot_quantiles_longer <- function(.data, ...) {
   names(long_tib)[1:2] <- c(glue::glue("{col}_value"), glue::glue("{col}_quantile_level"))
   out <- left_join(.data, long_tib, by = ".row") %>% select(!.row)
   if (inherits(.data, "epi_df")) {
-    attr(out, "metadata")$other_keys <- c(attr(.data, "metadata")$other_keys, glue::glue("{col}_quantile_level"))
+    # register the new quantile_level column as a key
+    out <- as_epi_df(
+      out,
+      as_of = attr(.data, "metadata")$as_of,
+      other_keys = c(attr(.data, "metadata")$other_keys, glue::glue("{col}_quantile_level"))
+    )
   }
   out
 }

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -1,0 +1,51 @@
+
+train_data <- epidatasets::cases_deaths_subset
+
+test_that("autoplot renders a single-target-date forecast (geom_linerange band)", {
+  fc <- arx_forecaster(
+    train_data,
+    "death_rate_7d_av",
+    c("death_rate_7d_av", "case_rate_7d_av"),
+    args_list = arx_args_list(ahead = 7L, quantile_levels = c(.1, .5, .9))
+  )
+  p <- autoplot(fc, observed_response = train_data)
+  expect_s3_class(p, "ggplot")
+  expect_silent(ggplot2::ggplot_build(p))
+})
+
+test_that("autoplot renders a multi-target-date forecast (geom_ribbon band)", {
+
+  forecast_date <- as.Date("2021-08-01")
+
+  # arx_forecaster only takes a scalar `ahead`, so a real multi-horizon
+  # forecast means forecasting each ahead separately and combining them.
+  all_canned_results <- lapply(
+    seq(0, 28),
+    \(days_ahead) {
+      arx_forecaster(
+        train_data |>
+          filter(time_value <= forecast_date),
+        outcome = "death_rate_7d_av",
+        predictors = c("case_rate_7d_av", "death_rate_7d_av"),
+        trainer = quantile_reg(),
+        args_list = arx_args_list(
+          lags = list(c(0, 1, 2, 3, 7, 14), c(0, 7, 14)),
+          ahead = days_ahead
+        )
+      )
+    }
+  )
+  # pull out the workflow and the predictions to be able to use autoplot
+  workflow <- all_canned_results[[1]]$epi_workflow
+  results <- all_canned_results |>
+    purrr::map(~ `$`(., "predictions")) |>
+    purrr::list_rbind()
+  p <- autoplot(
+    object = workflow,
+    predictions = results,
+    observed_response = train_data |>
+      filter(time_value > "2021-07-01")
+  )
+  expect_s3_class(p, "ggplot")
+  expect_silent(ggplot2::ggplot_build(p))
+})


### PR DESCRIPTION
### Checklist

Please:

- [ ] Make sure this PR is against "dev", not "main".
- [X] Request a review from one of the current epipredict main reviewers:
      dajmcdon.
- [ ] Make sure to bump the version number in `DESCRIPTION` and `NEWS.md`.
      Always increment the patch version number (the third number), unless you are
      making a release PR from dev to main, in which case increment the minor
      version number (the second number).
- [ ] Describe changes made in NEWS.md, making sure breaking changes
      (backwards-incompatible changes to the documented interface) are noted.
      Collect the changes under the next release number (e.g. if you are on
      0.7.2, then write your changes under the 0.8 heading).
- [ ] Consider pinning the `epiprocess` version in the `DESCRIPTION` file if
  - You anticipate breaking changes in `epiprocess` soon
  - You want to co-develop features in `epipredict` and `epiprocess`

### Change explanations for reviewer

This PR restores `.max_keys = Inf` in `autoplot.epi_workflow` and adds a test to ensure autoplot is working. 

### Magic GitHub syntax to mark associated Issue(s) as resolved when this is merged into the default branch
